### PR TITLE
add a drop command for the cache api

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -55,8 +55,19 @@ const getOrExec = async ({
   return value;
 };
 
+const drop = async ({
+  pluginName,
+  fn,
+  fnParams,
+}) => {
+  let key = hash({ fn, fnParams });
+  key = `${pluginName}:${key}`;
+  await cache.del(key);
+};
+
 module.exports = {
   cache,
   save,
   getOrExec,
+  drop,
 };


### PR DESCRIPTION
allow the ti2 api to expose a cache drop method to it's plugins.