### PR TITLE
Missing instance access on plugin methods for queryAllotment

### DIFF
--- a/controllers/allotment.js
+++ b/controllers/allotment.js
@@ -24,8 +24,7 @@ const queryAllotment = plugins => async (req, res, next) => {
     assert(userAppKeys, 'could not find the app key');
     const token = userAppKeys.appKey;
     assert(app.queryAllotment, 'could not find the allotment method');
-    const search = app.queryAllotment;
-    const results = await search({
+    const results = await app.queryAllotment({
       token,
       payload: query,
     });


### PR DESCRIPTION
queryAllotment method was not being called from the plugin instance itself  disallowing the methods to access the instance properties