### PR TITLE
Get duration for the product - useful for non-accomodation & packages…

### DIFF
--- a/controllers/graphql-schemas/itinerary-product.js
+++ b/controllers/graphql-schemas/itinerary-product.js
@@ -43,6 +43,7 @@ const typeDefs = `
     extras: [Extra]
     units: [ProductUnit]
     restrictions: OptionRestrictions
+    duration: Int
   }
 
   type Query {
@@ -66,6 +67,7 @@ const query = `{
     optionName
     comment
     lastUpdateTimestamp
+    duration
     serviceType
     extras {
       id

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -585,6 +585,7 @@ class Plugin {
    * @property {string} optionName - Option name
    * @property {string} comment - Option comment
    * @property {number} [lastUpdateTimestamp] - Last update time
+   * @property {number} [duration] - Duration of the service option in 24 hour periods (returned only if greater than 1). For most options this field is not relevant. Examples of options where duration is greater than one are multi-day packages, and multi-day sightseeing trips (river cruises for example).
    * @property {string} serviceType - Type of service, one of 'Accommodation', 'Activity', 'Transfer'
    * @property {Array<Extra>} extras - Extras allowed for this product option
    * @property {Array<ItineraryProductUnit>} units - Available units

--- a/tutorials/itinerary-assist-plugin-dev.md
+++ b/tutorials/itinerary-assist-plugin-dev.md
@@ -75,6 +75,7 @@ No, we don't have a specific test scenarios, but we recommend you to cover the f
         {
           "extras": [],
           "lastUpdateTimestamp": 1586595549,
+          "duration": 1,
           "comment": "This is a comment",
           "optionId": "106784",
           "optionName": "Bed and English Breakfast-Executive Room",
@@ -162,6 +163,7 @@ No, we don't have a specific test scenarios, but we recommend you to cover the f
         {
           "extras": [],
           "lastUpdateTimestamp": 1700750093,
+          "duration": 1,
           "comment": "This is a comment",
           "optionId": "LONTRDAVIDSHDWBVC",
           "optionName": "Half-Day Warner Bros Studios (6-Hours)-FIT- V- Class (1-5 Pax)",


### PR DESCRIPTION
get duration: should be useful to show the end date for non-accomodation and packages