### PR TITLE
fix: skip empty cache when no search filter and refactor cache logic

### DIFF
--- a/controllers/__tests__/bookings-searchProducts.js
+++ b/controllers/__tests__/bookings-searchProducts.js
@@ -285,7 +285,7 @@ describe('user: bookings controller - searchProducts', () => {
           expect(jobData.method).toBe(expectedPluginMethod);
           expect(jobData.token).toBeDefined(); // Token passed to the job
           expect(jobData.payload.userId).toBe(testUserId);
-          expect(jobData.payload.payload).toEqual({}); // Original payload for the plugin method was empty
+          expect(jobData.payload.payload).toEqual({ forceRefresh: false }); // Original payload for the plugin method
           expect(jobData.postProcess.controller).toBe('bookings');
           expect(jobData.postProcess.action).toBe('$updateProductSearchCache');
           expect(jobData.postProcess.args.appKey).toBe(testAppName);
@@ -512,7 +512,7 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
           method: expectedPluginMethodName,
           token: expect.objectContaining({ ttlForProducts: shortTTRTokenConfig.ttlForProducts }),
           payload: expect.objectContaining({
-            payload: {}, // originalRequestBody was empty for the product search
+            payload: { forceRefresh: false }, // originalRequestBody was empty for the product search
             userId: testUserId,
           }),
           postProcess: expect.objectContaining({


### PR DESCRIPTION
## Summary
- When cache exists but contains an empty product list and no search filter is applied, skip returning cached results and fetch fresh data from the plugin
- Refactored cache handling logic to improve readability:
  - Removed deeply nested else blocks
  - Added `returnCachedResults()` helper to avoid code repetition
  - Used early returns for clearer control flow

## Test plan
- [x] Added tests for empty cache + no filter scenario
- [x] Added tests for empty cache + filter scenario  
- [x] Added tests for cached products scenario
- [x] Fixed existing test assertions for payload structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)