### PR TITLE
docs: document shellOnly booking request for itinerary assist (TC-881)

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -451,6 +451,9 @@ components:
         id:
           type: string
           description: a quote Id to make a reservation for
+        shellOnly:
+          type: boolean
+          description: Optional itinerary-assist flag to create/update booking header only without adding a service line
     settingsBody:
       type: object
       required: true

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -718,12 +718,13 @@ class Plugin {
    * @param {string} args.payload.QB - 'Q' for quote, 'B' for booking
    * @param {string} args.payload.quoteName - Name of the booking/quote
    * @param {string} [args.payload.quoteId] - identifier of the booking/quote, if one is provided, we are expecting the service line to be inserted to an existing booking/quote
+   * @param {boolean} [args.payload.shellOnly] - Optional flag to create/update booking header only and skip service-line insertion
    * @param {string} [args.payload.lineId] - identifier of the service line in the booking/quote, if one is provided, we are expecting an existing service line to be updated
    * @param {string} [args.payload.rateId] - Rate identifier, we are sending 'Default' if no rates are provided by the check availability call
-   * @param {string} args.payload.optionId - Option identifier of the service line
-   * @param {string} args.payload.startDate - Start date always in (YYYY-MM-DD) format
+   * @param {string} args.payload.optionId - Option identifier of the service line (required unless shellOnly is true)
+   * @param {string} args.payload.startDate - Start date always in (YYYY-MM-DD) format (required unless shellOnly is true)
    * @param {string} [args.payload.reference] - Reference number from external system
-   * @param {Array<PaxConfig>} args.payload.paxConfigs - Passenger configurations
+   * @param {Array<PaxConfig>} args.payload.paxConfigs - Passenger configurations (required unless shellOnly is true)
    * @param {Array<Object>} [args.payload.extras] - Additional extras
    * @param {Extra} args.payload.extras.selectedExtra - Selected extra
    * @param {number} args.payload.extras.quantity - quantity

--- a/tutorials/itinerary-assist-plugin-dev.md
+++ b/tutorials/itinerary-assist-plugin-dev.md
@@ -267,8 +267,9 @@ No, we don't have a specific test scenarios, but we recommend you to cover the f
   quoteName: String,
   rateId: String,           // Optional
   quoteId: String,          // Optional
-  optionId: String,
-  startDate: String,        // YYYY-MM-DD
+  shellOnly: Boolean,       // Optional. If true, create/update quote header only and skip service insertion
+  optionId: String,         // Required unless shellOnly is true
+  startDate: String,        // YYYY-MM-DD, required unless shellOnly is true
   reference: String,        // Optional
   paxConfigs: [{
     roomType: String,       // Optional
@@ -280,7 +281,7 @@ No, we don't have a specific test scenarios, but we recommend you to cover the f
       dob: String,            // Optional, YYYY-MM-DD
       personId: String        // Optional
     }]
-  }],
+  }],                       // Required unless shellOnly is true
   extras: [{                // Optional
     selectedExtra: {
       id: String


### PR DESCRIPTION
## Summary
- document optional shellOnly field in bookingRequest schema
- update plugin contract docs for addServiceToItinerary to describe shell-only behavior
- update itinerary assist tutorial payload example with conditional required fields

## Why
TC-881 introduces shell quote creation when no services are matched. This PR documents the optional request field so plugin behavior is explicit and consistent.

## Validation
- reviewed API schema and docs alignment for itinerary-assist booking payload