### PR TITLE
hotfix: ti2 crash on corrupted app token + OPTIONS preflight handling

### DIFF
--- a/controllers/app.js
+++ b/controllers/app.js
@@ -480,43 +480,6 @@ const getAppSettings = async (req, res, next) => {
   return res.json({ settings: userIntegrationSettings.settings });
 };
 
-const isCorruptedStoredTokenError = err => {
-  if (!err) return false;
-
-  const message = typeof err.message === 'string'
-    ? err.message.toLowerCase()
-    : '';
-  const stack = typeof err.stack === 'string'
-    ? err.stack.toLowerCase()
-    : '';
-  const tokenPathInStack = stack.includes('lib/security.js')
-    || stack.includes('models/userappkey.js');
-  const knownCryptoErrors = [
-    'invalid initialization vector',
-    'bad decrypt',
-    'wrong final block length',
-  ];
-
-  if (err.code === 'ERR_INVALID_ARG_TYPE') return true;
-  if (knownCryptoErrors.some(knownError => message.includes(knownError))) return true;
-  if (tokenPathInStack && err.name === 'SyntaxError') return true;
-  if (tokenPathInStack && message.includes('unexpected')) return true;
-
-  return false;
-};
-
-const logInvalidStoredToken = ({ req, integrationId, userId, hint, err }) => {
-  console.warn('Invalid stored integration token', {
-    requestId: req.requestId,
-    integrationId,
-    userId,
-    hint,
-    errorCode: err.code,
-    errorName: err.name,
-    message: err.message,
-  });
-};
-
 const getAppToken = async (req, res, next) => {
   const {
     params: {
@@ -537,23 +500,10 @@ const getAppToken = async (req, res, next) => {
       },
     });
     if (!userAppKey) {
-      return next({ status: 404, message: `User integratio is not found for ${integrationId}:${userId}:${hint}` });
+      return next({ status: 404, message: `User integration is not found for ${integrationId}:${userId}:${hint}` });
     }
     return res.json({ token: await userAppKey.token });
   } catch (err) {
-    if (isCorruptedStoredTokenError(err)) {
-      logInvalidStoredToken({
-        req,
-        integrationId,
-        userId,
-        hint,
-        err,
-      });
-      return next({
-        status: 422,
-        message: 'Stored integration token is invalid. Please re-save credentials.',
-      });
-    }
     return next(err);
   }
 };

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ const rebuild = fn => obj =>
   Object.fromEntries(Object.entries(obj).flatMap(([k, v]) => fn(k, v)));
 
 const isNumber = value => !Number.isNaN(Number(value));
+const isCorruptedTokenError = err => R.pathOr(false, ['code'], err) === 'CORRUPTED_TOKEN';
 
 const axiosSafeRequest = R.pick(['headers', 'method', 'url', 'data']);
 const axiosSafeResponse = response => {
@@ -374,6 +375,17 @@ module.exports = async ({
     app.use(middleware.mock());
     // global error Handling
     app.use((err, req, res, next) => {
+      if (isCorruptedTokenError(err) && !process.env.JEST_WORKER_ID) {
+        console.warn('Invalid stored integration token', {
+          requestId: req.requestId,
+          integrationId: R.path(['context', 'integrationId'], err),
+          userId: R.path(['context', 'userId'], err),
+          hint: R.path(['context', 'hint'], err),
+          errorCode: R.path(['cause', 'code'], err),
+          errorName: R.path(['cause', 'name'], err),
+          message: R.path(['cause', 'message'], err),
+        });
+      }
       if (process.env.CONSOLE_ERRORS || process.env.JEST_WORKER_ID) {
         console.error(R.pathOr(err, ['response', 'data'], err));
       }

--- a/index.js
+++ b/index.js
@@ -163,6 +163,7 @@ module.exports = async ({
     if (apiDocs) {
       app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(allSchema));
     }
+    app.options('*', middleware.CORS(), (_req, res) => res.sendStatus(204));
     app.use(
       middleware.metadata(),
       middleware.CORS(),

--- a/lib/corrupted-token-error.js
+++ b/lib/corrupted-token-error.js
@@ -1,0 +1,22 @@
+const buildCorruptedTokenError = ({
+  integrationId,
+  userId,
+  hint,
+  cause,
+}) => {
+  const error = new Error(
+    'Stored integration token is invalid. Please re-save credentials.',
+  );
+  error.name = 'CorruptedTokenError';
+  error.code = 'CORRUPTED_TOKEN';
+  error.status = 422;
+  error.context = {
+    integrationId,
+    userId,
+    hint,
+  };
+  error.cause = cause;
+  return error;
+};
+
+module.exports = buildCorruptedTokenError;


### PR DESCRIPTION
## Incident
Requests that read user integration tokens could crash ti2 when stored `UserAppKeys.appKey` data is corrupted/invalid for decrypt.

## What changed
- moved corrupted-token handling to `models/userappkey.js` (single source of truth for all consumers)
- added typed `CorruptedTokenError` (`code=CORRUPTED_TOKEN`, `status=422`) in `lib/corrupted-token-error.js`
- token getter now decrypts once (removed duplicate decrypt) and wraps decrypt/parse failures in typed error
- global error middleware now logs structured warning context for `CorruptedTokenError` outside Jest
- removed endpoint-specific corruption matching logic from `getAppToken` and fixed typo in not-found message (`integration`)
- kept explicit global `OPTIONS` preflight handling before OpenAPI metadata resolution
- made corruption tests self-cleaning by restoring DB values in `finally`
- added regression test to prove non-`getAppToken` path (`bookings` endpoint) returns `422` for corrupted token

## Validation
- syntax check:
  - `node -c lib/corrupted-token-error.js`
  - `node -c models/userappkey.js`
  - `node -c controllers/app.js`
  - `node -c index.js`
  - `node -c controllers/__tests__/user.js`
  - `node -c controllers/__tests__/bookings.js`
- note: full Jest execution is blocked in this environment by DB host resolution (`SequelizeHostNotFoundError: getaddrinfo ENOTFOUND mysqlserver`)

## Risk
Low blast radius. No migration, no encryption primitive change. Behavior change is explicit `422` for corrupted stored integration credentials across all token consumers.
