### PR TITLE
TC-885: hotfix to ensure updated ti2 credentials are used, support legacy token

### DIFF
--- a/models/__tests__/userappkey.js
+++ b/models/__tests__/userappkey.js
@@ -1,0 +1,35 @@
+/* globals describe it expect */
+const { UserAppKey } = require('../index');
+
+describe('UserAppKey.mergeTokenPayload', () => {
+  it('uses appKey as base, then settings override same keys, then configuration', () => {
+    const appKey = { endpoint: 'https://old.example.com', apiKey: 'secret' };
+    const settings = { endpoint: 'https://updated.example.com', onlyInSettings: true };
+    const configuration = { foo: 'bar' };
+
+    const result = UserAppKey.mergeTokenPayload(appKey, settings, configuration);
+
+    expect(result.endpoint).toBe('https://updated.example.com');
+    expect(result.onlyInSettings).toBe(true);
+    expect(result.apiKey).toBe('secret');
+    expect(result.configuration).toEqual({ foo: 'bar' });
+  });
+
+  it('returns only appKey when settings and configuration are empty', () => {
+    const appKey = { access_token: 'x', refresh_token: 'y' };
+    const result = UserAppKey.mergeTokenPayload(appKey, {}, null);
+    expect(result).toEqual({ access_token: 'x', refresh_token: 'y' });
+  });
+
+  it('strips empty and nil values from appKey', () => {
+    const appKey = { a: 1, b: '', c: null, d: [] };
+    const result = UserAppKey.mergeTokenPayload(appKey, {}, null);
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('handles null/undefined appKey or settings', () => {
+    expect(UserAppKey.mergeTokenPayload(null, { x: 1 }, null)).toEqual({ x: 1 });
+    expect(UserAppKey.mergeTokenPayload({ a: 1 }, null, null)).toEqual({ a: 1 });
+    expect(UserAppKey.mergeTokenPayload({}, {}, undefined)).toEqual({});
+  });
+});


### PR DESCRIPTION
UserAppKey model (userappkey.js):
- In order to get updated credentials, change the merge order while getting the token: appKey as base, then UserIntegrationSettings (overrides same keys), then configuration.
- Extract merge logic into UserAppKey.mergeTokenPayload(appKey, settings, configuration) to add tests.
- Support legacy unencrypted JWT appKey: if appKey does not contain '%', decode via jwt.decode instead of decrypt + JSON.parse so old tokens continue to work.
- Add jsonwebtoken dependency for legacy token decoding.

Add Unit tests (models/__tests__/userappkey.js):
- Add tests for mergeTokenPayload

App controller tests (controllers/__tests__/app.js):
- Fix typos: 'airbitrary' -> 'arbitrary', 'shoul dbe re-syncjed' ->
  'should be re-synced'.
- Add 'token and settings merge' suite: getAppToken returns appKey payload; createAppSettings updates user settings; getAppToken returns merged token with settings overriding appKey and appKey-only keys preserved.