### PR TITLE
fix: serialize axios error responses correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ module.exports = async ({
             requestId: req.requestId,
             err: errMsg,
             ...(err.request ? { request: axiosSafeRequest(err.request) } : {}),
-            ...(err.response ? { response: axiosSafeRequest(err.response) } : {}),
+            ...(err.response ? { response: axiosSafeResponse(err.response) } : {}),
           });
         }
         return Promise.reject(errMsg);


### PR DESCRIPTION
## Summary
- fix axios error interceptor to serialize error response with axiosSafeResponse instead of request serializer

## Why
- preserves correct response shape in emitted axios error events
- avoids mislabeling response fields in logs