### PR TITLE
hotfix: guard token template regex serialization

### DIFF
--- a/controllers/app.js
+++ b/controllers/app.js
@@ -51,13 +51,19 @@ const tokenTemplate = async (req, res, next) => {
     const thePlugin = req.app.plugins.find(({ name }) => name === pluginName);
     assert(thePlugin);
     let template = thePlugin.tokenTemplate();
-    const safeRegExp = el => ({
-      ...el,
-      regExp: {
-        flags: el.regExp.flags,
-        source: el.regExp.source,
-      },
-    });
+    const safeRegExp = el => {
+      if (!el || !(el.regExp instanceof RegExp)) {
+        return el;
+      }
+
+      return {
+        ...el,
+        regExp: {
+          flags: el.regExp.flags,
+          source: el.regExp.source,
+        },
+      };
+    };
     template = R.map(safeRegExp, template);
     return res.json({
       template: {

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -123,6 +123,11 @@ class Plugin {
         regExp: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
         description: 'Api Key',
       },
+      testMode: {
+        type: 'boolean',
+        default: false,
+        description: 'Use test mode',
+      },
     }));
     this.errorPathsAxiosErrors = jestPlugin.fn(() => ([
       ['response', 'data', 'what'],


### PR DESCRIPTION
* Having an invalid value for a regex field on a plugin will error out the template url retrieval