### PR TITLE
TC-834 Add credential-aware integration flow support to ti2

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -151,6 +151,10 @@ components:
         payload:
           type: object
           example: random lorem
+    integrationCredentials:
+      description: Optional external-session credentials forwarded by the client
+      type: object
+      additionalProperties: true
     UserApp:
       description: A user + App configuration
       type: object
@@ -385,6 +389,9 @@ components:
           required: false
           description: Product Name wildcard match
           example: '*bus*'
+        credentials:
+          required: false
+          $ref: '#/components/schemas/integrationCredentials'
     bookingsProductSearchReturn:
       type: object
       additionalProperties: true
@@ -454,6 +461,9 @@ components:
         shellOnly:
           type: boolean
           description: Optional itinerary-assist flag to create/update booking header only without adding a service line
+        credentials:
+          required: false
+          $ref: '#/components/schemas/integrationCredentials'
     settingsBody:
       type: object
       required: true
@@ -1410,6 +1420,7 @@ paths:
                       $ref: '#/components/schemas/desk'
   /affiliate/{appKey}/{userId}/agents:
     get:
+      deprecated: true
       security:
         - bearerAuth: ['admin', 'user']
       tags:
@@ -1442,8 +1453,49 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/agent'
+    post:
+      security:
+        - bearerAuth: ['admin', 'user']
+      tags:
+        - bookings
+      summary: Gets all agents for this affiliate
+      operationId: getAffiliateAgents
+      parameters:
+        - name: appKey
+          in: path
+          description: name of the app to get the agents for (defaults to first token found)
+          required: true
+          example: 'fareharbor'
+          schema:
+            type: string
+        - name: userId
+          in: path
+          description: the user/company that the appKey belongs to
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Optional request metadata
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnyValue'
+      responses:
+        '200':
+          description: agents
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agents:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/agent'
   /affiliate/{appKey}/{userId}/{hint}/agents:
     get:
+      deprecated: true
       security:
         - bearerAuth: ['admin', 'user']
       tags:
@@ -1471,6 +1523,53 @@ paths:
           example: 'fareharbor-helloworld'
           schema:
             type: string
+      responses:
+        '200':
+          description: agents
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  agents:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/agent'
+    post:
+      security:
+        - bearerAuth: ['admin', 'user']
+      tags:
+        - bookings
+      summary: Gets all agents for this affiliate
+      operationId: getAffiliateAgents
+      parameters:
+        - name: appKey
+          in: path
+          description: name of the app to get the agents for the token using the hint
+          required: true
+          example: 'fareharbor'
+          schema:
+            type: string
+        - name: userId
+          in: path
+          description: the user/company that the appKey belongs to
+          required: true
+          schema:
+            type: string
+        - name: hint
+          in: path
+          description: a specific token hint to be used
+          required: true
+          example: 'fareharbor-helloworld'
+          schema:
+            type: string
+      requestBody:
+        description: Optional request metadata
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnyValue'
       responses:
         '200':
           description: agents
@@ -2256,6 +2355,7 @@ paths:
                 $ref: '#/components/schemas/AnyValue'
   /bookings/{appKey}/{userId}/custom-fields:
     get:
+      deprecated: true
       security:
         - bearerAuth: ['admin', 'user']
       tags:
@@ -2286,8 +2386,47 @@ paths:
                 properties:
                   fields:
                     type: array
+    post:
+      security:
+        - bearerAuth: ['admin', 'user']
+      tags:
+        - bookings
+      summary: Gets all custom fields for creating a booking
+      operationId: getCreateBookingFields
+      parameters:
+        - name: appKey
+          in: path
+          description: name of the app to get the resource for (defaults to first token found)
+          required: true
+          example: 'fareharbor'
+          schema:
+            type: string
+        - name: userId
+          in: path
+          description: the user/company that the appKey belongs to
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Optional field context and credentials
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnyValue'
+      responses:
+        '200':
+          description: fields
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  fields:
+                    type: array
   /bookings/{appKey}/{userId}/{hint}/custom-fields:
     get:
+      deprecated: true
       security:
         - bearerAuth: ['admin', 'user']
       tags:
@@ -2315,6 +2454,51 @@ paths:
           example: 'xola-helloworld'
           schema:
             type: string
+      responses:
+        '200':
+          description: fields
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  fields:
+                    type: array
+    post:
+      security:
+        - bearerAuth: ['admin', 'user']
+      tags:
+        - bookings
+      summary: Gets all custom fields for creating a booking
+      operationId: getCreateBookingFields
+      parameters:
+        - name: appKey
+          in: path
+          description: name of the app to get the resource for the token using the hint
+          required: true
+          example: 'xola'
+          schema:
+            type: string
+        - name: userId
+          in: path
+          description: the user/company that the appKey belongs to
+          required: true
+          schema:
+            type: string
+        - name: hint
+          in: path
+          description: a specific token hint to be used
+          required: true
+          example: 'xola-helloworld'
+          schema:
+            type: string
+      requestBody:
+        description: Optional field context and credentials
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnyValue'
       responses:
         '200':
           description: fields

--- a/controllers/__tests__/allotments.js
+++ b/controllers/__tests__/allotments.js
@@ -72,6 +72,8 @@ describe('allotment', () => {
     const call = plugins[0].queryAllotment.mock.calls[0][0];
     expect(call.payload).toEqual(payload);
     expect(call.token).toEqual(token);
+    expect(call.userId).toEqual(userId);
+    expect(call.hint).toBeUndefined();
   });
   it('should be able to get some allotments with a hint', async () => {
     const { allotments } = await doApiGet({
@@ -81,9 +83,11 @@ describe('allotment', () => {
     });
     expect(plugins[0].queryAllotment).toHaveBeenCalled();
     expect(Array.isArray(allotments)).toBeTruthy();
-    const call = plugins[0].queryAllotment.mock.calls[0][0];
+    const call = plugins[0].queryAllotment.mock.calls[plugins[0].queryAllotment.mock.calls.length - 1][0];
     expect(call.payload).toEqual(payload);
     expect(call.token).toEqual(token);
+    expect(call.userId).toEqual(userId);
+    expect(call.hint).toEqual(newIntegration.tokenHint);
   });
   it('should be able to receive an axios error', async () => {
     // Temporarily silence console.error for this test since we're expecting an error

--- a/controllers/__tests__/allotments.js
+++ b/controllers/__tests__/allotments.js
@@ -1,4 +1,4 @@
-/* globals beforeAll describe it expect jest */
+/* globals beforeAll beforeEach describe it expect jest */
 const axios = require('axios');
 const MockAdapter = require('axios-mock-adapter');
 const chance = require('chance').Chance();
@@ -28,6 +28,9 @@ describe('allotment', () => {
   let doApiPost;
   let plugins;
   let userToken;
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   beforeAll(async () => {
     ({
       doApiGet,
@@ -83,7 +86,7 @@ describe('allotment', () => {
     });
     expect(plugins[0].queryAllotment).toHaveBeenCalled();
     expect(Array.isArray(allotments)).toBeTruthy();
-    const call = plugins[0].queryAllotment.mock.calls[plugins[0].queryAllotment.mock.calls.length - 1][0];
+    const call = plugins[0].queryAllotment.mock.calls[0][0];
     expect(call.payload).toEqual(payload);
     expect(call.token).toEqual(token);
     expect(call.userId).toEqual(userId);

--- a/controllers/__tests__/bookings.js
+++ b/controllers/__tests__/bookings.js
@@ -350,5 +350,26 @@ describe('user: bookings controller', () => {
       expect(products).toHaveLength(1);
       expect(products[0].productName).toBe('Cached Product');
     });
+
+    it('should receive inline credentials only once before product search', async () => {
+      const payload = {
+        credentials: {
+          sessionValue: 'product-credential',
+        },
+      };
+
+      await doApiPost({
+        url: `/products/${appKey}/${userId}/testingToken/search`,
+        token: userToken,
+        payload,
+      });
+
+      expect(plugins[0].receiveCredentials).toHaveBeenCalledTimes(1);
+      expect(plugins[0].searchProducts).toHaveBeenCalledTimes(1);
+      expect(plugins[0].searchProducts.mock.calls[0][0].payload).toEqual({
+        ...payload,
+        forceRefresh: false,
+      });
+    });
   });
 });

--- a/controllers/__tests__/bookings.js
+++ b/controllers/__tests__/bookings.js
@@ -170,7 +170,7 @@ describe('user: bookings controller', () => {
     expect(plugins[0].createBooking.mock.calls[0][0].payload).toEqual(payload);
     expect(plugins[0].createBooking.mock.calls[0][0].token).toEqual(token);
   });
-  it('should forward inline credentials to receiveCredentials before create booking', async () => {
+  it('should forward inline credentials directly to create booking', async () => {
     const payload = {
       id: chance.guid(),
       credentials: {
@@ -182,9 +182,8 @@ describe('user: bookings controller', () => {
       token: userToken,
       payload,
     });
-    expect(plugins[0].receiveCredentials).toHaveBeenCalledTimes(1);
-    expect(plugins[0].receiveCredentials.mock.calls[0][0].payload).toEqual(payload);
     expect(plugins[0].createBooking).toHaveBeenCalled();
+    expect(plugins[0].createBooking.mock.calls[0][0].payload).toEqual(payload);
   });
   it('should support POST affiliate agents with inline credentials', async () => {
     const payload = {
@@ -198,7 +197,6 @@ describe('user: bookings controller', () => {
       payload,
     });
     expect(Array.isArray(agents)).toBeTruthy();
-    expect(plugins[0].receiveCredentials).toHaveBeenCalledTimes(1);
     expect(plugins[0].getAffiliateAgents).toHaveBeenCalledTimes(1);
     expect(plugins[0].getAffiliateAgents.mock.calls[0][0].payload).toEqual(payload);
   });
@@ -215,7 +213,6 @@ describe('user: bookings controller', () => {
       payload,
     });
     expect(response.customFields).toEqual([]);
-    expect(plugins[0].receiveCredentials).toHaveBeenCalledTimes(1);
     expect(plugins[0].getCreateItineraryFields).toHaveBeenCalledTimes(1);
     expect(plugins[0].getCreateItineraryFields.mock.calls[0][0].payload).toEqual(payload);
   });
@@ -351,7 +348,7 @@ describe('user: bookings controller', () => {
       expect(products[0].productName).toBe('Cached Product');
     });
 
-    it('should receive inline credentials only once before product search', async () => {
+    it('should forward inline credentials directly to product search', async () => {
       const payload = {
         credentials: {
           sessionValue: 'product-credential',
@@ -364,7 +361,6 @@ describe('user: bookings controller', () => {
         payload,
       });
 
-      expect(plugins[0].receiveCredentials).toHaveBeenCalledTimes(1);
       expect(plugins[0].searchProducts).toHaveBeenCalledTimes(1);
       expect(plugins[0].searchProducts.mock.calls[0][0].payload).toEqual({
         ...payload,

--- a/controllers/__tests__/bookings.js
+++ b/controllers/__tests__/bookings.js
@@ -170,6 +170,55 @@ describe('user: bookings controller', () => {
     expect(plugins[0].createBooking.mock.calls[0][0].payload).toEqual(payload);
     expect(plugins[0].createBooking.mock.calls[0][0].token).toEqual(token);
   });
+  it('should forward inline credentials to receiveCredentials before create booking', async () => {
+    const payload = {
+      id: chance.guid(),
+      credentials: {
+        sessionValue: 'abc123',
+      },
+    };
+    await doApiPost({
+      url: `/bookings/${appKey}/${userId}/testingToken/booking`,
+      token: userToken,
+      payload,
+    });
+    expect(plugins[0].receiveCredentials).toHaveBeenCalledTimes(1);
+    expect(plugins[0].receiveCredentials.mock.calls[0][0].payload).toEqual(payload);
+    expect(plugins[0].createBooking).toHaveBeenCalled();
+  });
+  it('should support POST affiliate agents with inline credentials', async () => {
+    const payload = {
+      credentials: {
+        sessionValue: 'agent-credential',
+      },
+    };
+    const { agents } = await doApiPost({
+      url: `/affiliate/${appKey}/${userId}/testingToken/agents`,
+      token: userToken,
+      payload,
+    });
+    expect(Array.isArray(agents)).toBeTruthy();
+    expect(plugins[0].receiveCredentials).toHaveBeenCalledTimes(1);
+    expect(plugins[0].getAffiliateAgents).toHaveBeenCalledTimes(1);
+    expect(plugins[0].getAffiliateAgents.mock.calls[0][0].payload).toEqual(payload);
+  });
+  it('should support POST custom-fields with inline credentials', async () => {
+    const payload = {
+      productId: 'prod-1',
+      credentials: {
+        sessionValue: 'fields-credential',
+      },
+    };
+    const response = await doApiPost({
+      url: `/bookings/${appKey}/${userId}/testingToken/custom-fields`,
+      token: userToken,
+      payload,
+    });
+    expect(response.customFields).toEqual([]);
+    expect(plugins[0].receiveCredentials).toHaveBeenCalledTimes(1);
+    expect(plugins[0].getCreateItineraryFields).toHaveBeenCalledTimes(1);
+    expect(plugins[0].getCreateItineraryFields.mock.calls[0][0].payload).toEqual(payload);
+  });
   it('should return 422 when stored app token is corrupted on bookings endpoint', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const [originalRows] = await sqldb.query(

--- a/controllers/allotment.js
+++ b/controllers/allotment.js
@@ -29,6 +29,8 @@ const queryAllotment = plugins => async (req, res, next) => {
       axios,
       token,
       payload: query,
+      userId,
+      hint,
       requestId: req.requestId,
     });
     return res.json(results);

--- a/controllers/allotment.js
+++ b/controllers/allotment.js
@@ -19,7 +19,7 @@ const queryAllotment = plugins => async (req, res, next) => {
       where: {
         userId,
         integrationId: appKey,
-        ...(hint ? { hint } : {}),
+        ...(hint && { hint }),
       },
     });
     assert(userAppKeys, 'could not find the app key');

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -43,26 +43,6 @@ const getAppAndToken = async ({ plugins, appKey, userId, hint }) => {
   return { app, token };
 };
 
-const maybeReceiveCredentials = async ({
-  app,
-  axios,
-  token,
-  payload,
-  userId,
-  hint,
-  requestId,
-}) => {
-  if (!(payload && payload.credentials && app && app.receiveCredentials)) return;
-  await app.receiveCredentials({
-    axios,
-    token,
-    payload,
-    userId,
-    hint,
-    requestId,
-  });
-};
-
 const bookingsSearch = plugins => async (req, res, next) => {
   const {
     axios,
@@ -73,15 +53,6 @@ const bookingsSearch = plugins => async (req, res, next) => {
     const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.searchItineraries || app.searchHotelBooking || app.searchBooking, `searchItineraries or searchHotelBooking or searchBooking is not available for ${appKey}`);
     const search = (app.searchHotelBooking || app.searchBooking || app.searchItineraries).bind(app);
-    await maybeReceiveCredentials({
-      app,
-      axios,
-      token,
-      payload: body,
-      userId,
-      hint,
-      requestId: req.requestId,
-    });
     const results = await search({
       axios,
       token,
@@ -105,15 +76,6 @@ const bookingsCancel = plugins => async (req, res, next) => {
   } = req;
   try {
     const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
-    await maybeReceiveCredentials({
-      app,
-      axios,
-      token,
-      payload: body,
-      userId,
-      hint,
-      requestId: req.requestId,
-    });
     const results = await app.cancelBooking({
       axios,
       token,
@@ -185,15 +147,6 @@ const $bookingsProductSearch = plugins => async ({
   assert(appKey, 'appKey is required');
   assert(app.searchProducts || app.searchProductsForItinerary, `searchProducts or searchProductsForItinerary is not available for ${appKey}`);
   const func = (app.searchProducts || app.searchProductsForItinerary).bind(app);
-  await maybeReceiveCredentials({
-    app,
-    axios,
-    token,
-    payload: payloadForPlugin,
-    userId,
-    hint,
-    requestId,
-  });
 
   const cacheKey = hash({ userId, hint, operationId: 'bookingsProductSearch' });
   const pluginExecutionLockKey = `${cacheKey}:lock`; // Lock for direct plugin execution
@@ -345,15 +298,6 @@ const getProductPackages = plugins => async (req, res, next) => {
   try {
     const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.getProductPackages, `getProductPackages is not available for ${appKey}`);
-    await maybeReceiveCredentials({
-      app,
-      axios,
-      token,
-      payload,
-      userId,
-      hint,
-      requestId: req.requestId,
-    });
     const results = await app.getProductPackages({
       axios,
       token,
@@ -378,15 +322,6 @@ const bookingsAvailabilitySearch = plugins => async (req, res, next) => {
   try {
     const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     const func = (app.searchAvailability || app.searchAvailabilityForItinerary).bind(app);
-    await maybeReceiveCredentials({
-      app,
-      axios,
-      token,
-      payload,
-      userId,
-      hint,
-      requestId: req.requestId,
-    });
     const results = await func({
       axios,
       token,
@@ -412,15 +347,6 @@ const $bookingsAvailabilityCalendar = plugins => async ({
 }) => {
   const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
   assert(app.availabilityCalendar, `availabilityCalendar is not available for ${appKey}`);
-  await maybeReceiveCredentials({
-    app,
-    axios,
-    token,
-    payload,
-    userId,
-    hint,
-    requestId,
-  });
   return app.availabilityCalendar({
     axios,
     token,
@@ -459,15 +385,6 @@ const searchQuote = plugins => async (req, res, next) => {
   } = req;
   try {
     const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
-    await maybeReceiveCredentials({
-      app,
-      axios,
-      token,
-      payload,
-      userId,
-      hint,
-      requestId: req.requestId,
-    });
     const results = await app.searchQuote({
       axios,
       token,
@@ -496,15 +413,6 @@ const createBooking = plugins => async (req, res, next) => {
     if (payload.mock) {
       results = { mock: true, success: true, bookingId: '1234567890' };
     } else {
-      await maybeReceiveCredentials({
-        app,
-        axios,
-        token,
-        payload,
-        userId,
-        hint,
-        requestId: req.requestId,
-      });
       results = await func({
         axios,
         token,
@@ -539,15 +447,6 @@ const getAffiliateAgents = plugins => async (req, res, next) => {
   try {
     const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.getAffiliateAgents, `getAffiliateAgents is not available for ${appKey}`);
-    await maybeReceiveCredentials({
-      app,
-      axios,
-      token,
-      payload,
-      userId,
-      hint,
-      requestId: req.requestId,
-    });
     const results = await app.getAffiliateAgents({
       axios,
       token,
@@ -571,15 +470,6 @@ const getAffiliateDesks = plugins => async (req, res, next) => {
   try {
     const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.getAffiliateDesks, `getAffiliateDesks is not available for ${appKey}`);
-    await maybeReceiveCredentials({
-      app,
-      axios,
-      token,
-      payload,
-      userId,
-      hint,
-      requestId: req.requestId,
-    });
     const results = await app.getAffiliateDesks({
       axios,
       token,
@@ -603,15 +493,6 @@ const getPickupPoints = plugins => async (req, res, next) => {
   try {
     const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.getPickupPoints, `getPickupPoints is not available for ${appKey}`);
-    await maybeReceiveCredentials({
-      app,
-      axios,
-      token,
-      payload,
-      userId,
-      hint,
-      requestId: req.requestId,
-    });
     const results = await app.getPickupPoints({
       axios,
       token,
@@ -638,15 +519,6 @@ const getCreateBookingFields = plugins => async (req, res, next) => {
     const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.getCreateBookingFields || app.getCreateItineraryFields, `getCreateBookingFields or getCreateItineraryFields is not available for ${appKey}`);
     const func = (app.getCreateItineraryFields || app.getCreateBookingFields).bind(app);
-    await maybeReceiveCredentials({
-      app,
-      axios,
-      token,
-      payload,
-      userId,
-      hint,
-      requestId: req.requestId,
-    });
     const results = await func({
       axios,
       token,

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -35,7 +35,7 @@ const getAppAndToken = async ({ plugins, appKey, userId, hint }) => {
     where: {
       userId,
       integrationId: appKey,
-      ...(hint ? { hint } : {}),
+      ...(hint && { hint }),
     },
   });
   assert(userAppKeys, 'could not find the app key');

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -30,6 +30,7 @@ const typeDefsAndQueries = {
 
 const getAppAndToken = async ({ plugins, appKey, userId, hint }) => {
   const app = plugins.find(({ name }) => name === appKey);
+  assert(app, 'could not find the app ' + appKey);
   const userAppKeys = await UserAppKey.findOne({
     where: {
       userId,
@@ -211,15 +212,6 @@ const $bookingsProductSearch = plugins => async ({
     await app.cache.save({ key: pluginExecutionLockKey, value: true, ttl: 120 });
     let pluginResults;
     try {
-      await maybeReceiveCredentials({
-        app,
-        axios,
-        token,
-        payload: payloadForPlugin,
-        userId,
-        hint,
-        requestId,
-      });
       pluginResults = await func({
         axios,
         token,
@@ -523,7 +515,7 @@ const createBooking = plugins => async (req, res, next) => {
         requestId: req.requestId,
       });
     }
-    console.log(`emitting bookingsCreateBooking event for ${appKey}, user ${userId}, hint ${hint}, results: ${JSON.stringify(results)}`);
+    console.debug(`emitting bookingsCreateBooking event for ${appKey}, user ${userId}, hint ${hint}, results: ${JSON.stringify(results)}`);
     app.events.emit('bookingsCreateBooking', {
       userId,
       hint,
@@ -579,6 +571,15 @@ const getAffiliateDesks = plugins => async (req, res, next) => {
   try {
     const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.getAffiliateDesks, `getAffiliateDesks is not available for ${appKey}`);
+    await maybeReceiveCredentials({
+      app,
+      axios,
+      token,
+      payload,
+      userId,
+      hint,
+      requestId: req.requestId,
+    });
     const results = await app.getAffiliateDesks({
       axios,
       token,
@@ -602,6 +603,15 @@ const getPickupPoints = plugins => async (req, res, next) => {
   try {
     const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.getPickupPoints, `getPickupPoints is not available for ${appKey}`);
+    await maybeReceiveCredentials({
+      app,
+      axios,
+      token,
+      payload,
+      userId,
+      hint,
+      requestId: req.requestId,
+    });
     const results = await app.getPickupPoints({
       axios,
       token,
@@ -609,6 +619,7 @@ const getPickupPoints = plugins => async (req, res, next) => {
       typeDefsAndQueries,
       userId,
       hint,
+      requestId: req.requestId,
     });
     return res.json(results);
   } catch (err) {

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -28,6 +28,40 @@ const typeDefsAndQueries = {
   itineraryBookingQuery,
 };
 
+const getAppAndToken = async ({ plugins, appKey, userId, hint }) => {
+  const app = plugins.find(({ name }) => name === appKey);
+  const userAppKeys = await UserAppKey.findOne({
+    where: {
+      userId,
+      integrationId: appKey,
+      ...(hint ? { hint } : {}),
+    },
+  });
+  assert(userAppKeys, 'could not find the app key');
+  const token = await userAppKeys.token;
+  return { app, token };
+};
+
+const maybeReceiveCredentials = async ({
+  app,
+  axios,
+  token,
+  payload,
+  userId,
+  hint,
+  requestId,
+}) => {
+  if (!(payload && payload.credentials && app && app.receiveCredentials)) return;
+  await app.receiveCredentials({
+    axios,
+    token,
+    payload,
+    userId,
+    hint,
+    requestId,
+  });
+};
+
 const bookingsSearch = plugins => async (req, res, next) => {
   const {
     axios,
@@ -35,23 +69,25 @@ const bookingsSearch = plugins => async (req, res, next) => {
     body,
   } = req;
   try {
-    const app = plugins.find(({ name }) => name === appKey);
-    const userAppKeys = await UserAppKey.findOne({
-      where: {
-        userId,
-        integrationId: appKey,
-        ...(hint ? { hint } : {}),
-      },
-    });
-    assert(userAppKeys, 'could not find the app key');
-    const token = await userAppKeys.token;
+    const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.searchItineraries || app.searchHotelBooking || app.searchBooking, `searchItineraries or searchHotelBooking or searchBooking is not available for ${appKey}`);
     const search = (app.searchHotelBooking || app.searchBooking || app.searchItineraries).bind(app);
+    await maybeReceiveCredentials({
+      app,
+      axios,
+      token,
+      payload: body,
+      userId,
+      hint,
+      requestId: req.requestId,
+    });
     const results = await search({
       axios,
       token,
       payload: body,
       typeDefsAndQueries,
+      userId,
+      hint,
       requestId: req.requestId,
     });
     return res.json(results);
@@ -67,22 +103,23 @@ const bookingsCancel = plugins => async (req, res, next) => {
     body,
   } = req;
   try {
-    const app = plugins.find(({ name }) => name === appKey);
-    // const app = load(appKey);
-    const userAppKeys = (await UserAppKey.findOne({
-      where: {
-        userId,
-        integrationId: appKey,
-        ...(hint ? { hint } : {}),
-      },
-    }));
-    assert(userAppKeys, 'could not find the app key');
-    const token = await userAppKeys.token;
+    const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
+    await maybeReceiveCredentials({
+      app,
+      axios,
+      token,
+      payload: body,
+      userId,
+      hint,
+      requestId: req.requestId,
+    });
     const results = await app.cancelBooking({
       axios,
       token,
       payload: body,
       typeDefsAndQueries,
+      userId,
+      hint,
       requestId: req.requestId,
     });
     return res.json(results);
@@ -140,17 +177,22 @@ const $bookingsProductSearch = plugins => async ({
 
   // Payload for the plugin function (func) - pass forceRefresh so plugins can trigger background cache rebuilds
   const payloadForPlugin = { ...R.omit(['forceRefresh'], originalRequestBody), forceRefresh };
+  const payloadForBackgroundJob = R.omit(['credentials'], payloadForPlugin);
 
-  const app = plugins.find(({ name }) => name === appKey);
+  const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
   assert(userId, 'userId is required');
   assert(appKey, 'appKey is required');
   assert(app.searchProducts || app.searchProductsForItinerary, `searchProducts or searchProductsForItinerary is not available for ${appKey}`);
-  const userAppKeys = (await UserAppKey.findOne({
-    where: { userId, integrationId: appKey, ...(hint ? { hint } : {}) },
-  }));
-  assert(userAppKeys, 'could not find the app key');
-  const token = await userAppKeys.token;
   const func = (app.searchProducts || app.searchProductsForItinerary).bind(app);
+  await maybeReceiveCredentials({
+    app,
+    axios,
+    token,
+    payload: payloadForPlugin,
+    userId,
+    hint,
+    requestId,
+  });
 
   const cacheKey = hash({ userId, hint, operationId: 'bookingsProductSearch' });
   const pluginExecutionLockKey = `${cacheKey}:lock`; // Lock for direct plugin execution
@@ -169,8 +211,23 @@ const $bookingsProductSearch = plugins => async ({
     await app.cache.save({ key: pluginExecutionLockKey, value: true, ttl: 120 });
     let pluginResults;
     try {
+      await maybeReceiveCredentials({
+        app,
+        axios,
+        token,
+        payload: payloadForPlugin,
+        userId,
+        hint,
+        requestId,
+      });
       pluginResults = await func({
-        axios, token, payload: payloadForPlugin, typeDefsAndQueries, requestId, userId,
+        axios,
+        token,
+        payload: payloadForPlugin,
+        typeDefsAndQueries,
+        requestId,
+        userId,
+        hint,
       });
 
       // This function is responsible for caching if it fetched good results.
@@ -244,7 +301,7 @@ const $bookingsProductSearch = plugins => async ({
         pluginName: appKey,
         method: app.searchProducts ? 'searchProducts' : 'searchProductsForItinerary',
         token,
-        payload: { payload: payloadForPlugin, userId },
+        payload: { payload: payloadForBackgroundJob, userId, hint },
         postProcess: {
           controller: 'bookings',
           action: '$updateProductSearchCache',
@@ -294,23 +351,24 @@ const getProductPackages = plugins => async (req, res, next) => {
     body: payload,
   } = req;
   try {
-    const app = plugins.find(({ name }) => name === appKey);
-    // const app = load(appKey);
-    const userAppKeys = (await UserAppKey.findOne({
-      where: {
-        userId,
-        integrationId: appKey,
-        ...(hint ? { hint } : {}),
-      },
-    }));
-    assert(userAppKeys, 'could not find the app key');
+    const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.getProductPackages, `getProductPackages is not available for ${appKey}`);
-    const token = await userAppKeys.token;
+    await maybeReceiveCredentials({
+      app,
+      axios,
+      token,
+      payload,
+      userId,
+      hint,
+      requestId: req.requestId,
+    });
     const results = await app.getProductPackages({
       axios,
       token,
       payload,
       typeDefsAndQueries,
+      userId,
+      hint,
       requestId: req.requestId,
     });
     return res.json(results);
@@ -326,23 +384,24 @@ const bookingsAvailabilitySearch = plugins => async (req, res, next) => {
     body: payload,
   } = req;
   try {
-    const app = plugins.find(({ name }) => name === appKey);
-    // const app = load(appKey);
-    const userAppKeys = (await UserAppKey.findOne({
-      where: {
-        userId,
-        integrationId: appKey,
-        ...(hint ? { hint } : {}),
-      },
-    }));
-    assert(userAppKeys, 'could not find the app key');
-    const token = await userAppKeys.token;
+    const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     const func = (app.searchAvailability || app.searchAvailabilityForItinerary).bind(app);
+    await maybeReceiveCredentials({
+      app,
+      axios,
+      token,
+      payload,
+      userId,
+      hint,
+      requestId: req.requestId,
+    });
     const results = await func({
       axios,
       token,
       payload,
       typeDefsAndQueries,
+      userId,
+      hint,
       requestId: req.requestId,
     });
     return res.json(results);
@@ -359,23 +418,24 @@ const $bookingsAvailabilityCalendar = plugins => async ({
   payload,
   requestId,
 }) => {
-  const app = plugins.find(({ name }) => name === appKey);
-  // const app = load(appKey);
-  const userAppKeys = (await UserAppKey.findOne({
-    where: {
-      userId,
-      integrationId: appKey,
-      ...(hint ? { hint } : {}),
-    },
-  }));
-  assert(userAppKeys, 'could not find the app key');
+  const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
   assert(app.availabilityCalendar, `availabilityCalendar is not available for ${appKey}`);
-  const token = await userAppKeys.token;
+  await maybeReceiveCredentials({
+    app,
+    axios,
+    token,
+    payload,
+    userId,
+    hint,
+    requestId,
+  });
   return app.availabilityCalendar({
     axios,
     token,
     payload,
     typeDefsAndQueries,
+    userId,
+    hint,
     requestId,
   });
 };
@@ -406,22 +466,23 @@ const searchQuote = plugins => async (req, res, next) => {
     body: payload,
   } = req;
   try {
-    const app = plugins.find(({ name }) => name === appKey);
-    // const app = load(appKey);
-    const userAppKeys = (await UserAppKey.findOne({
-      where: {
-        userId,
-        integrationId: appKey,
-        ...(hint ? { hint } : {}),
-      },
-    }));
-    assert(userAppKeys, 'could not find the app key');
-    const token = await userAppKeys.token;
+    const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
+    await maybeReceiveCredentials({
+      app,
+      axios,
+      token,
+      payload,
+      userId,
+      hint,
+      requestId: req.requestId,
+    });
     const results = await app.searchQuote({
       axios,
       token,
       payload,
       typeDefsAndQueries,
+      userId,
+      hint,
       requestId: req.requestId,
     });
     return res.json(results);
@@ -437,27 +498,28 @@ const createBooking = plugins => async (req, res, next) => {
     body: payload,
   } = req;
   try {
-    const app = plugins.find(({ name }) => name === appKey);
-    // const app = load(appKey);
-    const userAppKeys = (await UserAppKey.findOne({
-      where: {
-        userId,
-        integrationId: appKey,
-        ...(hint ? { hint } : {}),
-      },
-    }));
-    assert(userAppKeys, 'could not find the app key');
-    const token = await userAppKeys.token;
+    const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     const func = (app.createBooking || app.addServiceToItinerary).bind(app);
     let results;
     if (payload.mock) {
       results = { mock: true, success: true, bookingId: '1234567890' };
     } else {
+      await maybeReceiveCredentials({
+        app,
+        axios,
+        token,
+        payload,
+        userId,
+        hint,
+        requestId: req.requestId,
+      });
       results = await func({
         axios,
         token,
         payload,
         typeDefsAndQueries,
+        userId,
+        hint,
         requestId: req.requestId,
       });
     }
@@ -483,22 +545,23 @@ const getAffiliateAgents = plugins => async (req, res, next) => {
     body: payload,
   } = req;
   try {
-    const app = plugins.find(({ name }) => name === appKey);
-    // const app = load(appKey);
-    const userAppKeys = (await UserAppKey.findOne({
-      where: {
-        userId,
-        integrationId: appKey,
-        ...(hint ? { hint } : {}),
-      },
-    }));
-    assert(userAppKeys, 'could not find the app key');
-    const token = await userAppKeys.token;
+    const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.getAffiliateAgents, `getAffiliateAgents is not available for ${appKey}`);
+    await maybeReceiveCredentials({
+      app,
+      axios,
+      token,
+      payload,
+      userId,
+      hint,
+      requestId: req.requestId,
+    });
     const results = await app.getAffiliateAgents({
       axios,
       token,
       payload,
+      userId,
+      hint,
       requestId: req.requestId,
     });
     return res.json(results);
@@ -514,22 +577,14 @@ const getAffiliateDesks = plugins => async (req, res, next) => {
     body: payload,
   } = req;
   try {
-    const app = plugins.find(({ name }) => name === appKey);
-    // const app = load(appKey);
-    const userAppKeys = (await UserAppKey.findOne({
-      where: {
-        userId,
-        integrationId: appKey,
-        ...(hint ? { hint } : {}),
-      },
-    }));
-    assert(userAppKeys, 'could not find the app key');
-    const token = await userAppKeys.token;
+    const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.getAffiliateDesks, `getAffiliateDesks is not available for ${appKey}`);
     const results = await app.getAffiliateDesks({
       axios,
       token,
       payload,
+      userId,
+      hint,
       requestId: req.requestId,
     });
     return res.json(results);
@@ -545,23 +600,15 @@ const getPickupPoints = plugins => async (req, res, next) => {
     body: payload,
   } = req;
   try {
-    const app = plugins.find(({ name }) => name === appKey);
-    // const app = load(appKey);
-    const userAppKeys = (await UserAppKey.findOne({
-      where: {
-        userId,
-        integrationId: appKey,
-        ...(hint ? { hint } : {}),
-      },
-    }));
-    assert(userAppKeys, 'could not find the app key');
-    const token = await userAppKeys.token;
+    const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.getPickupPoints, `getPickupPoints is not available for ${appKey}`);
     const results = await app.getPickupPoints({
       axios,
       token,
       payload,
       typeDefsAndQueries,
+      userId,
+      hint,
     });
     return res.json(results);
   } catch (err) {
@@ -577,25 +624,27 @@ const getCreateBookingFields = plugins => async (req, res, next) => {
     body: payload,
   } = req;
   try {
-    const app = plugins.find(({ name }) => name === appKey);
-    // const app = load(appKey);
-    const userAppKeys = (await UserAppKey.findOne({
-      where: {
-        userId,
-        integrationId: appKey,
-        ...(hint ? { hint } : {}),
-      },
-    }));
-    assert(userAppKeys, 'could not find the app key');
-    const token = await userAppKeys.token;
+    const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.getCreateBookingFields || app.getCreateItineraryFields, `getCreateBookingFields or getCreateItineraryFields is not available for ${appKey}`);
     const func = (app.getCreateItineraryFields || app.getCreateBookingFields).bind(app);
+    await maybeReceiveCredentials({
+      app,
+      axios,
+      token,
+      payload,
+      userId,
+      hint,
+      requestId: req.requestId,
+    });
     const results = await func({
       axios,
       token,
       payload,
       query,
       typeDefsAndQueries,
+      userId,
+      hint,
+      requestId: req.requestId,
     });
     return res.json(results);
   } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ti2",
-  "version": "1.0.107",
+  "version": "1.0.109",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ti2",
-      "version": "1.0.107",
+      "version": "1.0.109",
       "license": "GPL-3.0",
       "dependencies": {
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2",
-  "version": "1.0.108-beta.0",
+  "version": "1.0.109-beta.0",
   "description": "Tourist Industry Exchange (TI2)",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2",
-  "version": "1.0.109-beta.0",
+  "version": "1.0.109",
   "description": "Tourist Industry Exchange (TI2)",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2",
-  "version": "1.0.107",
+  "version": "1.0.108-beta.0",
   "description": "Tourist Industry Exchange (TI2)",
   "main": "index.js",
   "scripts": {

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -75,7 +75,6 @@ class Plugin {
     });
     this.searchQuote = jestPlugin.fn(() => ({ quote: [{ id: chance.guid() }] }));
     this.createBooking = jestPlugin.fn(() => {});
-    this.receiveCredentials = jestPlugin.fn(() => ({}));
     this.getAffiliateAgents = jestPlugin.fn(() => ({ agents: [] }));
     this.searchItineraries = jestPlugin.fn(() => ({ bookings: [] }));
     this.searchProductsForItinerary = jestPlugin.fn(() => ({ products: [] }));

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -75,6 +75,8 @@ class Plugin {
     });
     this.searchQuote = jestPlugin.fn(() => ({ quote: [{ id: chance.guid() }] }));
     this.createBooking = jestPlugin.fn(() => {});
+    this.receiveCredentials = jestPlugin.fn(() => ({}));
+    this.getAffiliateAgents = jestPlugin.fn(() => ({ agents: [] }));
     this.searchItineraries = jestPlugin.fn(() => ({ bookings: [] }));
     this.searchProductsForItinerary = jestPlugin.fn(() => ({ products: [] }));
     this.searchAvailabilityForItinerary = jestPlugin.fn(({


### PR DESCRIPTION
## Summary
- add generic `receiveCredentials` dispatch for credential-aware plugins
- add POST credential-aware routes and schemas for agents and custom fields
- thread TourPlan NX read-session context through allotment and booking flows

## Validation
- focused controller tests passed in the TC-834 worktree: `controllers/__tests__/allotments.js` and `controllers/__tests__/bookings.js`
