### PR TITLE
TC-1032 Pass validate payload to plugins

### DIFF
--- a/controllers/__tests__/user.js
+++ b/controllers/__tests__/user.js
@@ -219,6 +219,9 @@ describe('user', () => {
     expect(plugins[0].validateToken).toHaveBeenCalled();
     expect(valid).toBe(true);
     expect(plugins[0].validateToken.mock.calls[0][0].token).toEqual({ custom: true, ...token });
+    expect(plugins[0].validateToken.mock.calls[0][0].payload).toEqual({
+      tokenHint: apiKey.split('-')[0],
+    });
   });
   it('should be able to delete an app settings', async () => {
     const returnValue = await doApiDelete({

--- a/controllers/app.js
+++ b/controllers/app.js
@@ -260,6 +260,7 @@ const validateAppToken = plugins => async (req, res, next) => {
     const valid = await app.validateToken({
       axios,
       token,
+      payload: req.body,
       requestId: req.requestId,
     });
     return res.json({ valid });


### PR DESCRIPTION
 Forward request payload into plugin  calls so plugins can inspect session-required context (, inline credentials).

- Updated tests to verify payload forwarding in  controller.
- Enables downstream  external session validation flow without cache reads/saves.\n