### PR TITLE
chore: bump version to 1.0.114

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ti2",
-  "version": "1.0.111",
+  "version": "1.0.114",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ti2",
-      "version": "1.0.111",
+      "version": "1.0.114",
       "license": "GPL-3.0",
       "dependencies": {
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2",
-  "version": "1.0.111",
+  "version": "1.0.114",
   "description": "Tourist Industry Exchange (TI2)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump `package.json` to `1.0.114`
- bump the root package version in `package-lock.json` to `1.0.114`

## Why
The new release flow tags `v<package.json version>` from the current `main` commit.

`main` was still at `1.0.111`, but tags `v1.0.111`, `v1.0.112`, and `v1.0.113` already exist, so the release workflow correctly failed on duplicate tag creation. This PR moves `main` to the next unused release version so the tag-only workflow can run successfully.