### PR TITLE
fix: prefer itinerary booking search when available

### DIFF
--- a/controllers/__tests__/bookings.js
+++ b/controllers/__tests__/bookings.js
@@ -106,10 +106,10 @@ describe('user: bookings controller', () => {
         token: userToken,
         payload,
       });
-      expect(plugins[0].searchHotelBooking).toHaveBeenCalled();
+      expect(plugins[0].searchItineraries).toHaveBeenCalled();
       expect(Array.isArray(bookings)).toBeTruthy();
-      expect(plugins[0].searchHotelBooking.mock.calls[0][0].payload).toEqual(payload);
-      expect(plugins[0].searchHotelBooking.mock.calls[0][0].token).toEqual(token);
+      expect(plugins[0].searchItineraries.mock.calls[0][0].payload).toEqual(payload);
+      expect(plugins[0].searchItineraries.mock.calls[0][0].token).toEqual(token);
     });
 
   });

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -52,7 +52,8 @@ const bookingsSearch = plugins => async (req, res, next) => {
   try {
     const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
     assert(app.searchItineraries || app.searchHotelBooking || app.searchBooking, `searchItineraries or searchHotelBooking or searchBooking is not available for ${appKey}`);
-    const search = (app.searchHotelBooking || app.searchBooking || app.searchItineraries).bind(app);
+    // Prefer the dedicated itinerary endpoint so date/filter payloads used by mining are preserved.
+    const search = (app.searchItineraries || app.searchHotelBooking || app.searchBooking).bind(app);
     const results = await search({
       axios,
       token,


### PR DESCRIPTION
Prioritize searchItineraries in bookings search so itinerary-capable plugins keep richer date/filter
semantics for mining flows, while preserving fallback compatibility for integrations that only implement legacy booking methods.