### PR TITLE
TC-1139: pass validation context to plugins

### DIFF
--- a/controllers/__tests__/user.js
+++ b/controllers/__tests__/user.js
@@ -222,6 +222,19 @@ describe('user', () => {
     expect(plugins[0].validateToken.mock.calls[0][0].payload).toEqual({
       tokenHint: apiKey.split('-')[0],
     });
+    expect(plugins[0].validateToken.mock.calls[0][0].userId).toBe(userId);
+    expect(plugins[0].validateToken.mock.calls[0][0].hint).toBe(apiKey.split('-')[0]);
+  });
+  it('testing the user token should not infer a hint when no hint is provided', async () => {
+    const { valid } = await doApiPost({
+      url: `/${appName}/${userId}/validate`,
+      token: userKey,
+      payload: {},
+    });
+    expect(plugins[0].validateToken).toHaveBeenCalled();
+    expect(valid).toBe(true);
+    expect(plugins[0].validateToken.mock.calls[0][0].userId).toBe(userId);
+    expect(plugins[0].validateToken.mock.calls[0][0].hint).toBeUndefined();
   });
   it('should be able to delete an app settings', async () => {
     const returnValue = await doApiDelete({

--- a/controllers/app.js
+++ b/controllers/app.js
@@ -261,6 +261,8 @@ const validateAppToken = plugins => async (req, res, next) => {
       axios,
       token,
       payload: req.body,
+      userId,
+      hint,
       requestId: req.requestId,
     });
     return res.json({ valid });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ti2",
-  "version": "1.0.114",
+  "version": "1.0.115",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ti2",
-      "version": "1.0.114",
+      "version": "1.0.115",
       "license": "GPL-3.0",
       "dependencies": {
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2",
-  "version": "1.0.114",
+  "version": "1.0.115",
   "description": "Tourist Industry Exchange (TI2)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Forward `userId` and explicit `tokenHint` into plugin `validateToken()` calls.
- Preserve no-hint validation behavior without inferring a saved-session hint.
- Add coverage for explicit-hint forwarding and no-hint validation.
- Bump package version to `1.0.115`.

## Validation
- `make run-ti2-base WORKDIR=./ti2_TC-1139 EXTRA_VOLUMES='/Users/xalakox/sites/tourconnect/ti2/node_modules:/ti2/node_modules' CMD='npm --prefix /ti2 test -- controllers/__tests__/user.js --forceExit'`
- `git diff --check`

## Release
- After merge to `main`, run the ti2 release workflow on `main`; it should create tag `v1.0.115`.