### PR TITLE
TC-1211: protect product search cache refresh

### DIFF
--- a/__tests__/cache.js
+++ b/__tests__/cache.js
@@ -15,6 +15,30 @@ describe('cache', () => {
   });
 
 
+  describe('saveIfNotExists', () => {
+    it('should only save the first value for a key', async () => {
+      const key = 'lock:test';
+      testKeys.push(key);
+
+      const firstSaved = await cache.saveIfNotExists({
+        pluginName: testPluginName,
+        key,
+        value: { owner: 'first' },
+        ttl: 60,
+      });
+      const secondSaved = await cache.saveIfNotExists({
+        pluginName: testPluginName,
+        key,
+        value: { owner: 'second' },
+        ttl: 60,
+      });
+
+      expect(firstSaved).toBe(true);
+      expect(secondSaved).toBe(false);
+      expect(await cache.get({ pluginName: testPluginName, key })).toEqual({ owner: 'first' });
+    });
+  });
+
   describe('scan', () => {
     it('should return keys matching the pattern without plugin prefix', async () => {
       // Save some test keys

--- a/cache.js
+++ b/cache.js
@@ -25,6 +25,22 @@ const save = async ({
   }
 };
 
+const saveIfNotExists = async ({
+  pluginName,
+  key: keyParam,
+  value,
+  ttl = defaultTTL,
+}) => {
+  const key = `${pluginName}:${(() => {
+    if (typeof keyParam !== 'string') {
+      return hash(keyParam);
+    }
+    return keyParam;
+  })()}`;
+  const result = await cache.set(key, JSON.stringify(value), 'EX', ttl, 'NX');
+  return result === 'OK';
+};
+
 const get = async ({
   pluginName,
   key: keyParam,
@@ -116,6 +132,7 @@ const scan = ({
 module.exports = {
   cache,
   save,
+  saveIfNotExists,
   getOrExec,
   drop,
   get,

--- a/cache.js
+++ b/cache.js
@@ -5,6 +5,23 @@ const REDIS_URL = process.env.REDIS_URL || 'redis://redis:6379';
 const cache = new Redis(`${REDIS_URL}/2`);
 const defaultTTL = 60 * 60; // 1 hour
 
+const normalizeKey = ({
+  key: keyParam,
+  fn,
+  fnParams,
+  useFunctionFallback = false,
+}) => {
+  if (useFunctionFallback && !keyParam) {
+    return hash({ fn, fnParams });
+  }
+  if (typeof keyParam !== 'string') {
+    return hash(keyParam);
+  }
+  return keyParam;
+};
+
+const buildKey = ({ pluginName, ...args }) => `${pluginName}:${normalizeKey(args)}`;
+
 const save = async ({
   pluginName,
   key: keyParam,
@@ -12,12 +29,7 @@ const save = async ({
   skipTTL,
   ttl = defaultTTL,
 }) => {
-  const key = `${pluginName}:${(() => {
-    if (typeof keyParam !== 'string') {
-      return hash(keyParam);
-    }
-    return keyParam;
-  })()}`;
+  const key = buildKey({ pluginName, key: keyParam });
   // console.log('saving key', key);
   await cache.set(key, JSON.stringify(value));
   if (!skipTTL) {
@@ -31,12 +43,7 @@ const saveIfNotExists = async ({
   value,
   ttl = defaultTTL,
 }) => {
-  const key = `${pluginName}:${(() => {
-    if (typeof keyParam !== 'string') {
-      return hash(keyParam);
-    }
-    return keyParam;
-  })()}`;
+  const key = buildKey({ pluginName, key: keyParam });
   const result = await cache.set(key, JSON.stringify(value), 'EX', ttl, 'NX');
   return result === 'OK';
 };
@@ -45,12 +52,7 @@ const get = async ({
   pluginName,
   key: keyParam,
 }) => {
-  const key = `${pluginName}:${(() => {
-    if (typeof keyParam !== 'string') {
-      return hash(keyParam);
-    }
-    return keyParam;
-  })()}`;
+  const key = buildKey({ pluginName, key: keyParam });
   const storeVal = await cache.get(key);
   if (!storeVal) return storeVal;
   return JSON.parse(storeVal);
@@ -64,15 +66,7 @@ const getOrExec = async ({
   fnParams,
   forceRefresh,
 }) => {
-  const key = (() => {
-    if (!keyParam) {
-      return hash({ fn, fnParams });
-    }
-    if (typeof keyParam !== 'string') {
-      return hash(keyParam);
-    }
-    return keyParam;
-  })();
+  const key = normalizeKey({ key: keyParam, fn, fnParams, useFunctionFallback: true });
   let value;
   if (!forceRefresh) {
     value = await get({ pluginName, key });
@@ -94,15 +88,13 @@ const drop = async ({
   fn,
   fnParams,
 }) => {
-  const key = `${pluginName}:${(() => {
-    if (!keyParam) {
-      return hash({ fn, fnParams });
-    }
-    if (typeof keyParam !== 'string') {
-      return hash(keyParam);
-    }
-    return keyParam;
-  })()}`;
+  const key = buildKey({
+    pluginName,
+    key: keyParam,
+    fn,
+    fnParams,
+    useFunctionFallback: true,
+  });
   // console.log('dropping key', key);
   await cache.del(key);
 };

--- a/controllers/__tests__/bookings-searchProducts.js
+++ b/controllers/__tests__/bookings-searchProducts.js
@@ -315,8 +315,8 @@ describe('user: bookings controller - searchProducts', () => {
 
     beforeEach(async () => {
       // Clear mocks
-      if (travelgatePlugin && travelgatePlugin.searchProducts && travelgatePlugin.searchProducts.mockClear) {
-        travelgatePlugin.searchProducts.mockClear();
+      if (travelgatePlugin && travelgatePlugin.searchProducts && travelgatePlugin.searchProducts.mockReset) {
+        travelgatePlugin.searchProducts.mockReset();
       }
       if (addJob && addJob.mockClear) {
         addJob.mockClear();
@@ -342,7 +342,7 @@ describe('user: bookings controller - searchProducts', () => {
           token: staleCacheTokenConfig,
       });
       // Clear mocks that might have been called during appSetup
-      if (travelgatePlugin.searchProducts.mockClear) travelgatePlugin.searchProducts.mockClear();
+      if (travelgatePlugin.searchProducts.mockReset) travelgatePlugin.searchProducts.mockReset();
       if (addJob.mockClear) addJob.mockClear();
     });
 
@@ -435,7 +435,6 @@ describe('user: bookings controller - searchProducts', () => {
           reason: 'emptyResultPreservedExistingCache',
           cachePreserved: true,
           existingProductCount: initialProductsInCache.length,
-          pluginResult: { products: [] },
         }),
       );
       emitSpy.mockRestore();
@@ -581,7 +580,6 @@ describe('user: bookings controller - searchProducts', () => {
           reason: 'emptyResultPreservedConcurrentCache',
           cachePreserved: true,
           existingProductCount: 1,
-          pluginResult,
         }),
       );
     });

--- a/controllers/__tests__/bookings-searchProducts.js
+++ b/controllers/__tests__/bookings-searchProducts.js
@@ -640,6 +640,24 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
     await cache.drop({ pluginName: testAppName, key: `${cacheKey}:jobLock` }); // jobQueueLock
   });
 
+  const clearProductSearchCache = async () => {
+    const cacheKey = hash({
+      userId: testUserId,
+      hint: ttrTestHint,
+      operationId: 'bookingsProductSearch',
+    });
+    await cache.drop({ pluginName: testAppName, key: cacheKey });
+    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:lastUpdated` });
+    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:lock` });
+    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:jobLock` });
+  };
+
+  const makeProductSearchRequest = () => doApiPost({
+    url: `/products/${testAppName}/${testUserId}/${ttrTestHint}/search`,
+    token: userToken,
+    payload: {},
+  });
+
   beforeEach(async () => {
     // Clear mocks before each test in this suite
     addJob.mockClear(); // Reset addJob mock calls
@@ -726,15 +744,7 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
   });
 
   it('multiple concurrent requests with no cache should wait for one plugin fetch', async () => {
-    const cacheKey = hash({
-      userId: testUserId,
-      hint: ttrTestHint,
-      operationId: 'bookingsProductSearch',
-    });
-    await cache.drop({ pluginName: testAppName, key: cacheKey });
-    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:lastUpdated` });
-    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:lock` });
-    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:jobLock` });
+    await clearProductSearchCache();
 
     const coldProducts = [{
       productId: 'cold-product',
@@ -755,13 +765,7 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
       });
     });
 
-    const makeRequest = () => doApiPost({
-      url: `/products/${testAppName}/${testUserId}/${ttrTestHint}/search`,
-      token: userToken,
-      payload: {},
-    });
-
-    const requestPromises = [makeRequest(), makeRequest(), makeRequest()];
+    const requestPromises = [makeProductSearchRequest(), makeProductSearchRequest(), makeProductSearchRequest()];
     await pluginFetchStarted;
     await new Promise(resolve => setTimeout(resolve, 50));
 
@@ -776,15 +780,7 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
   });
 
   it('multiple concurrent requests with no cache should share an empty plugin result', async () => {
-    const cacheKey = hash({
-      userId: testUserId,
-      hint: ttrTestHint,
-      operationId: 'bookingsProductSearch',
-    });
-    await cache.drop({ pluginName: testAppName, key: cacheKey });
-    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:lastUpdated` });
-    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:lock` });
-    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:jobLock` });
+    await clearProductSearchCache();
 
     lockTestPlugin.searchProducts.mockReset();
     const releasePluginFetches = [];
@@ -797,13 +793,7 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
       });
     });
 
-    const makeRequest = () => doApiPost({
-      url: `/products/${testAppName}/${testUserId}/${ttrTestHint}/search`,
-      token: userToken,
-      payload: {},
-    });
-
-    const requestPromises = [makeRequest(), makeRequest(), makeRequest()];
+    const requestPromises = [makeProductSearchRequest(), makeProductSearchRequest(), makeProductSearchRequest()];
     await pluginFetchStarted;
     await new Promise(resolve => setTimeout(resolve, 50));
 
@@ -818,15 +808,7 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
   });
 
   it('multiple concurrent requests with no cache should fail when the leader throws', async () => {
-    const cacheKey = hash({
-      userId: testUserId,
-      hint: ttrTestHint,
-      operationId: 'bookingsProductSearch',
-    });
-    await cache.drop({ pluginName: testAppName, key: cacheKey });
-    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:lastUpdated` });
-    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:lock` });
-    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:jobLock` });
+    await clearProductSearchCache();
 
     lockTestPlugin.searchProducts.mockReset();
     let rejectPluginFetch;
@@ -839,13 +821,7 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
       });
     });
 
-    const makeRequest = () => doApiPost({
-      url: `/products/${testAppName}/${testUserId}/${ttrTestHint}/search`,
-      token: userToken,
-      payload: {},
-    });
-
-    const requestPromises = [makeRequest(), makeRequest(), makeRequest()]
+    const requestPromises = [makeProductSearchRequest(), makeProductSearchRequest(), makeProductSearchRequest()]
       .map(requestPromise => requestPromise
         .then(result => ({ status: 'fulfilled', result }))
         .catch(error => ({ status: 'rejected', error })));

--- a/controllers/__tests__/bookings-searchProducts.js
+++ b/controllers/__tests__/bookings-searchProducts.js
@@ -774,4 +774,94 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
     expect(lockTestPlugin.searchProducts).toHaveBeenCalledTimes(1);
     expect(addJob).not.toHaveBeenCalled();
   });
+
+  it('multiple concurrent requests with no cache should share an empty plugin result', async () => {
+    const cacheKey = hash({
+      userId: testUserId,
+      hint: ttrTestHint,
+      operationId: 'bookingsProductSearch',
+    });
+    await cache.drop({ pluginName: testAppName, key: cacheKey });
+    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:lastUpdated` });
+    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:lock` });
+    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:jobLock` });
+
+    lockTestPlugin.searchProducts.mockReset();
+    const releasePluginFetches = [];
+    const pluginFetchStarted = new Promise(resolve => {
+      lockTestPlugin.searchProducts.mockImplementation(() => {
+        resolve();
+        return new Promise(pluginResolve => {
+          releasePluginFetches.push(() => pluginResolve({ products: [] }));
+        });
+      });
+    });
+
+    const makeRequest = () => doApiPost({
+      url: `/products/${testAppName}/${testUserId}/${ttrTestHint}/search`,
+      token: userToken,
+      payload: {},
+    });
+
+    const requestPromises = [makeRequest(), makeRequest(), makeRequest()];
+    await pluginFetchStarted;
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    releasePluginFetches.forEach(releasePluginFetch => releasePluginFetch());
+    const results = await Promise.all(requestPromises);
+
+    results.forEach(result => {
+      expect(result.products).toEqual([]);
+    });
+    expect(lockTestPlugin.searchProducts).toHaveBeenCalledTimes(1);
+    expect(addJob).not.toHaveBeenCalled();
+  });
+
+  it('multiple concurrent requests with no cache should fail when the leader throws', async () => {
+    const cacheKey = hash({
+      userId: testUserId,
+      hint: ttrTestHint,
+      operationId: 'bookingsProductSearch',
+    });
+    await cache.drop({ pluginName: testAppName, key: cacheKey });
+    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:lastUpdated` });
+    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:lock` });
+    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:jobLock` });
+
+    lockTestPlugin.searchProducts.mockReset();
+    let rejectPluginFetch;
+    const pluginFetchStarted = new Promise(resolve => {
+      lockTestPlugin.searchProducts.mockImplementation(() => {
+        resolve();
+        return new Promise((_, reject) => {
+          rejectPluginFetch = () => reject(new Error('boom'));
+        });
+      });
+    });
+
+    const makeRequest = () => doApiPost({
+      url: `/products/${testAppName}/${testUserId}/${ttrTestHint}/search`,
+      token: userToken,
+      payload: {},
+    });
+
+    const requestPromises = [makeRequest(), makeRequest(), makeRequest()]
+      .map(requestPromise => requestPromise
+        .then(result => ({ status: 'fulfilled', result }))
+        .catch(error => ({ status: 'rejected', error })));
+    await pluginFetchStarted;
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    rejectPluginFetch();
+    const results = await Promise.all(requestPromises);
+
+    results.forEach(result => {
+      expect(result.status).toBe('rejected');
+    });
+    expect(lockTestPlugin.searchProducts).toHaveBeenCalledTimes(1);
+    expect(addJob).not.toHaveBeenCalled();
+
+    const statuses = results.map(result => result.error.response.status).sort();
+    expect(statuses).toEqual([500, 503, 503]);
+  });
 });

--- a/controllers/__tests__/bookings-searchProducts.js
+++ b/controllers/__tests__/bookings-searchProducts.js
@@ -3,7 +3,6 @@
 const chance = require('chance').Chance();
 const hash = require('object-hash');
 const cache = require('../../cache');
-const bookingsControllerFactory = require('../bookings');
 // Remove direct import of listJobs, jobStatus as we'll mock addJob
 // const { listJobs, jobStatus } = require('../../worker/queue');
 
@@ -17,6 +16,7 @@ jest.mock('../../worker/queue', () => ({
 const { addJob, jobStatus: mockJobStatus } = require('../../worker/queue'); // Now addJob is the mock
 
 const testUtils = require('../../test/utils'); // Require the module itself
+const bookingsControllerFactory = require('../bookings');
 
 // Global setup for the entire test file
 let globalDoApiPost, globalPlugins, globalUtils, globalSqldb;
@@ -346,9 +346,14 @@ describe('user: bookings controller - searchProducts', () => {
       if (addJob.mockClear) addJob.mockClear();
     });
 
-    it('should return stale (non-empty) products when TTR expires and refresh yields empty products', async () => {
+    it('should return stale products and preserve the cache when refresh yields empty products', async () => {
       const initialProductsInCache = [{ productId: 'staleProd1', name: 'Stale Product One', optionId: 'optStale1' }];
       const productsFromPluginRefresh = []; // Simulate plugin returning empty on refresh
+      const cacheKeyForTest = hash({
+        userId: testUserId,
+        hint: staleCacheTestHint,
+        operationId: 'bookingsProductSearch',
+      });
 
       // 1. First call: Populate the cache with initialProductsInCache
       travelgatePlugin.searchProducts.mockResolvedValueOnce({ products: initialProductsInCache });
@@ -718,5 +723,55 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
         { removeOnComplete: true }
       );
     }
+  });
+
+  it('multiple concurrent requests with no cache should wait for one plugin fetch', async () => {
+    const cacheKey = hash({
+      userId: testUserId,
+      hint: ttrTestHint,
+      operationId: 'bookingsProductSearch',
+    });
+    await cache.drop({ pluginName: testAppName, key: cacheKey });
+    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:lastUpdated` });
+    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:lock` });
+    await cache.drop({ pluginName: testAppName, key: `${cacheKey}:jobLock` });
+
+    const coldProducts = [{
+      productId: 'cold-product',
+      productName: 'Cold Product',
+      options: [{
+        optionId: 'cold-option',
+        optionName: 'Cold Option',
+      }],
+    }];
+    lockTestPlugin.searchProducts.mockReset();
+    const releasePluginFetches = [];
+    const pluginFetchStarted = new Promise(resolve => {
+      lockTestPlugin.searchProducts.mockImplementation(() => {
+        resolve();
+        return new Promise(pluginResolve => {
+          releasePluginFetches.push(() => pluginResolve({ products: coldProducts }));
+        });
+      });
+    });
+
+    const makeRequest = () => doApiPost({
+      url: `/products/${testAppName}/${testUserId}/${ttrTestHint}/search`,
+      token: userToken,
+      payload: {},
+    });
+
+    const requestPromises = [makeRequest(), makeRequest(), makeRequest()];
+    await pluginFetchStarted;
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    releasePluginFetches.forEach(releasePluginFetch => releasePluginFetch());
+    const results = await Promise.all(requestPromises);
+
+    results.forEach(result => {
+      expect(result.products).toEqual(coldProducts);
+    });
+    expect(lockTestPlugin.searchProducts).toHaveBeenCalledTimes(1);
+    expect(addJob).not.toHaveBeenCalled();
   });
 });

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -28,9 +28,15 @@ const typeDefsAndQueries = {
   itineraryBookingQuery,
 };
 
-const productSearchLockTtlSeconds = 120;
-const productSearchLockWaitMs = 25 * 1000;
-const productSearchLockPollMs = 250;
+const getPositiveIntegerEnv = (name, defaultValue) => {
+  const value = Number(process.env[name]);
+  const integerValue = Math.floor(value);
+  return Number.isFinite(value) && integerValue > 0 ? integerValue : defaultValue;
+};
+
+const productSearchLockTtlSeconds = getPositiveIntegerEnv('PRODUCT_SEARCH_LOCK_TTL_SECONDS', 120);
+const productSearchLockWaitMs = getPositiveIntegerEnv('PRODUCT_SEARCH_LOCK_WAIT_MS', 25 * 1000);
+const productSearchLockPollMs = getPositiveIntegerEnv('PRODUCT_SEARCH_LOCK_POLL_MS', 250);
 const emptyProductSearchCacheTtlSeconds = 60;
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -28,6 +28,17 @@ const typeDefsAndQueries = {
   itineraryBookingQuery,
 };
 
+const productSearchLockTtlSeconds = 120;
+const productSearchLockWaitMs = 110 * 1000;
+const productSearchLockPollMs = 250;
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const createProductSearchInProgressError = () => {
+  const err = new Error('Product search cache refresh is already in progress');
+  err.status = 503;
+  return err;
+};
+
 const getAppAndToken = async ({ plugins, appKey, userId, hint }) => {
   const app = plugins.find(({ name }) => name === appKey);
   assert(app, 'could not find the app ' + appKey);
@@ -177,9 +188,53 @@ const $bookingsProductSearch = plugins => async ({
   const doNotCallPluginForProducts = token.doNotCallPluginForProducts || R.path(['cacheSettings', 'bookingsProductSearch', 'doNotCall'], app);
   const hasPluginExecutionLock = await app.cache.get({ key: pluginExecutionLockKey });
 
+  const getCachedProductSearchResults = async () => {
+    const cacheContent = await app.cache.get({ key: cacheKey });
+    if (cacheContent && cacheContent.products) return cacheContent;
+    return null;
+  };
+
+  const waitForProductSearchCache = async () => {
+    const timeoutAt = Date.now() + productSearchLockWaitMs;
+    while (Date.now() < timeoutAt) {
+      const cacheContent = await getCachedProductSearchResults();
+      if (cacheContent) return cacheContent;
+
+      const lockStillActive = await app.cache.get({ key: pluginExecutionLockKey });
+      if (!lockStillActive) return null;
+
+      await sleep(productSearchLockPollMs);
+    }
+
+    return getCachedProductSearchResults();
+  };
+
+  const acquirePluginExecutionLock = async () => {
+    if (app.cache.saveIfNotExists) {
+      return app.cache.saveIfNotExists({
+        key: pluginExecutionLockKey,
+        value: true,
+        ttl: productSearchLockTtlSeconds,
+      });
+    }
+
+    if (await app.cache.get({ key: pluginExecutionLockKey })) return false;
+    await app.cache.save({ key: pluginExecutionLockKey, value: true, ttl: productSearchLockTtlSeconds });
+    return true;
+  };
+
   // Helper function to call the plugin, save cache, and return results
-  const fetchFromPluginAndCache = async () => {
-    await app.cache.save({ key: pluginExecutionLockKey, value: true, ttl: 120 });
+  const fetchFromPluginAndCache = async ({ waitForExistingFetch = true } = {}) => {
+    const lockAcquired = await acquirePluginExecutionLock();
+    if (!lockAcquired) {
+      if (waitForExistingFetch) {
+        const cacheContent = await waitForProductSearchCache();
+        if (cacheContent) return cacheContent;
+      }
+
+      throw createProductSearchInProgressError();
+    }
+
     let pluginResults;
     try {
       pluginResults = await func({

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -29,12 +29,13 @@ const typeDefsAndQueries = {
 };
 
 const productSearchLockTtlSeconds = 120;
-const productSearchLockWaitMs = 110 * 1000;
+const productSearchLockWaitMs = 25 * 1000;
 const productSearchLockPollMs = 250;
+const emptyProductSearchCacheTtlSeconds = 60;
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-const createProductSearchInProgressError = () => {
-  const err = new Error('Product search cache refresh is already in progress');
+const createProductSearchUnavailableError = () => {
+  const err = new Error('Product search cache refresh did not produce cached results');
   err.status = 503;
   return err;
 };
@@ -187,6 +188,7 @@ const $bookingsProductSearch = plugins => async ({
   const isStaleByTTR = lastUpdated && (Date.now() - lastUpdated > ttr * 1000);
   const doNotCallPluginForProducts = token.doNotCallPluginForProducts || R.path(['cacheSettings', 'bookingsProductSearch', 'doNotCall'], app);
   const hasPluginExecutionLock = await app.cache.get({ key: pluginExecutionLockKey });
+  assert(app.cache.saveIfNotExists, 'cache adapter must expose saveIfNotExists');
 
   const getCachedProductSearchResults = async () => {
     const cacheContent = await app.cache.get({ key: cacheKey });
@@ -210,29 +212,20 @@ const $bookingsProductSearch = plugins => async ({
   };
 
   const acquirePluginExecutionLock = async () => {
-    if (app.cache.saveIfNotExists) {
-      return app.cache.saveIfNotExists({
-        key: pluginExecutionLockKey,
-        value: true,
-        ttl: productSearchLockTtlSeconds,
-      });
-    }
-
-    if (await app.cache.get({ key: pluginExecutionLockKey })) return false;
-    await app.cache.save({ key: pluginExecutionLockKey, value: true, ttl: productSearchLockTtlSeconds });
-    return true;
+    return app.cache.saveIfNotExists({
+      key: pluginExecutionLockKey,
+      value: true,
+      ttl: productSearchLockTtlSeconds,
+    });
   };
 
   // Helper function to call the plugin, save cache, and return results
-  const fetchFromPluginAndCache = async ({ waitForExistingFetch = true } = {}) => {
+  const fetchFromPluginAndCache = async () => {
     const lockAcquired = await acquirePluginExecutionLock();
     if (!lockAcquired) {
-      if (waitForExistingFetch) {
-        const cacheContent = await waitForProductSearchCache();
-        if (cacheContent) return cacheContent;
-      }
-
-      throw createProductSearchInProgressError();
+      const cacheContent = await waitForProductSearchCache();
+      if (cacheContent) return cacheContent;
+      throw createProductSearchUnavailableError();
     }
 
     let pluginResults;
@@ -247,7 +240,7 @@ const $bookingsProductSearch = plugins => async ({
         hint,
       });
 
-      // This function is responsible for caching if it fetched good results.
+      // This function is responsible for caching if it fetched usable results.
       // This applies to forceRefresh, initial load, or direct calls that result in a fetch.
       // The $updateProductSearchCache function handles caching for background jobs queued due to stale data.
       if (hasCacheableProductResults(pluginResults)) {
@@ -262,10 +255,10 @@ const $bookingsProductSearch = plugins => async ({
           cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
           reason: 'directPartialResultNotCached', pluginResult: pluginResults,
         });
+      } else if (pluginResults && pluginResults.products && pluginResults.products.length === 0) {
+        // Short-lived empty cache gives concurrent waiters the same answer as the lock holder.
+        await app.cache.save({ key: cacheKey, value: pluginResults, ttl: emptyProductSearchCacheTtlSeconds });
       }
-      // If pluginResults are empty, cache is NOT updated here by fetchFromPluginAndCache.
-      // This maintains existing behavior for forceRefresh/initial load paths.
-      // $updateProductSearchCache has its own logic for handling empty results from background refresh.
     } finally {
       await app.cache.drop({ key: pluginExecutionLockKey });
     }
@@ -310,14 +303,16 @@ const $bookingsProductSearch = plugins => async ({
         return returnCachedResults();
       }
 
-      // Cache is stale - check if background job already queued
-      const hasJobQueueLock = await app.cache.get({ key: jobQueueLockKey });
-      if (hasJobQueueLock) {
+      // Cache is stale - queue at most one background refresh job and serve stale data.
+      const jobQueueLockAcquired = await app.cache.saveIfNotExists({
+        key: jobQueueLockKey,
+        value: true,
+        ttl: 60,
+      });
+      if (!jobQueueLockAcquired) {
         return returnCachedResults();
       }
 
-      // Queue background refresh job and serve stale data
-      await app.cache.save({ key: jobQueueLockKey, value: true, ttl: 60 });
       await addJob({
         type: 'plugin',
         pluginName: appKey,
@@ -647,14 +642,15 @@ const $updateProductSearchCache = plugins => async ({
     const existingCacheContent = await app.cache.get({ key: cacheKey });
     if (hasNonEmptyProductCache(existingCacheContent)) {
       await markRefreshAttempted();
+      const eventExtra = {
+        reason: isPartialRefresh ? 'partialResultPreservedExistingCache' : 'emptyResultPreservedExistingCache',
+        cachePreserved: true,
+        existingProductCount: existingCacheContent.products.length,
+      };
+      if (isPartialRefresh) eventExtra.pluginResult = pluginResult;
       emitCacheEvent(
         isPartialRefresh ? 'bookingsProductSearch:cache:partialRefreshSkipped' : 'bookingsProductSearch:cache:emptyRefreshSkipped',
-        {
-          reason: isPartialRefresh ? 'partialResultPreservedExistingCache' : 'emptyResultPreservedExistingCache',
-          cachePreserved: true,
-          existingProductCount: existingCacheContent.products.length,
-          pluginResult,
-        },
+        eventExtra,
       );
       return;
     }
@@ -677,7 +673,6 @@ const $updateProductSearchCache = plugins => async ({
         reason: 'emptyResultPreservedConcurrentCache',
         cachePreserved: true,
         existingProductCount: latestCacheContent.products.length,
-        pluginResult,
       });
       return;
     }
@@ -685,7 +680,7 @@ const $updateProductSearchCache = plugins => async ({
     // Empty complete refreshes are authoritative only when there is no existing non-empty cache.
     await markRefreshAttempted();
     await app.cache.save({ key: cacheKey, value: { products: [] }, ttl: monthInSeconds });
-    emitCacheEvent('bookingsProductSearch:cache:emptyRefresh', { pluginResult });
+    emitCacheEvent('bookingsProductSearch:cache:emptyRefresh');
   }
 };
 

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -211,13 +211,11 @@ const $bookingsProductSearch = plugins => async ({
     return getCachedProductSearchResults();
   };
 
-  const acquirePluginExecutionLock = async () => {
-    return app.cache.saveIfNotExists({
-      key: pluginExecutionLockKey,
-      value: true,
-      ttl: productSearchLockTtlSeconds,
-    });
-  };
+  const acquirePluginExecutionLock = async () => app.cache.saveIfNotExists({
+    key: pluginExecutionLockKey,
+    value: true,
+    ttl: productSearchLockTtlSeconds,
+  });
 
   // Helper function to call the plugin, save cache, and return results
   const fetchFromPluginAndCache = async () => {

--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ module.exports = async ({
         get: args => cache.get({ ...args, pluginName }),
         getOrExec: args => cache.getOrExec({ ...args, pluginName }),
         save: args => cache.save({ ...args, pluginName }),
+        saveIfNotExists: args => cache.saveIfNotExists({ ...args, pluginName }),
         scan: args => cache.scan({ ...args, pluginName }),
       },
       axios: pluginAxios,


### PR DESCRIPTION
## Summary
- Add an atomic plugin-scoped cache helper using Redis `SET NX`.
- Single-flight true cold/no-cache product-search catalog builds so concurrent requests do not duplicate expensive plugin work.
- Preserve existing non-empty product caches when a background refresh returns empty/no products, while keeping stale-cache serving and one background refresh job unchanged.
- Address review feedback by sharing short-lived empty cold results with waiters, capping waiters below the current upstream caller timeout, using atomic stale-refresh job locking, and adding leader-empty/leader-throws regression coverage.
- Allow `PRODUCT_SEARCH_LOCK_TTL_SECONDS`, `PRODUCT_SEARCH_LOCK_WAIT_MS`, and `PRODUCT_SEARCH_LOCK_POLL_MS` env overrides while preserving current defaults.

## Validation
- `make run-ti2-base WORKDIR=./ti2_TC-1211 EXTRA_VOLUMES='/Users/xalakox/sites/tourconnect/ti2/node_modules:/ti2/node_modules' CMD='cd /ti2 && ./node_modules/.bin/jest __tests__/cache.js controllers/__tests__/bookings-searchProducts.js controllers/__tests__/bookings.js --forceExit'`
- Result: 3 suites / 37 tests passed.
- GitHub CI: passed https://github.com/ti2travel/ti2/actions/runs/27343625112/job/80786471680

## Notes
- Stale non-empty caches are still served immediately while a background refresh runs.
- The wait/single-flight path only applies when there is no usable product cache to serve.