### PR TITLE
Preserve product cache on partial refresh

### DIFF
--- a/controllers/__tests__/bookings-searchProducts.js
+++ b/controllers/__tests__/bookings-searchProducts.js
@@ -426,7 +426,12 @@ describe('user: bookings controller - searchProducts', () => {
       expect(lastUpdated).toBeGreaterThan(1);
       expect(emitSpy).toHaveBeenCalledWith(
         'bookingsProductSearch:cache:emptyRefreshSkipped',
-        expect.objectContaining({ pluginResult: { products: [] } }),
+        expect.objectContaining({
+          reason: 'emptyResultPreservedExistingCache',
+          cachePreserved: true,
+          existingProductCount: initialProductsInCache.length,
+          pluginResult: { products: [] },
+        }),
       );
       emitSpy.mockRestore();
     });
@@ -520,7 +525,12 @@ describe('user: bookings controller - searchProducts', () => {
       expect(lastUpdated).toBeGreaterThan(1);
       expect(emitSpy).toHaveBeenCalledWith(
         'bookingsProductSearch:cache:partialRefreshSkipped',
-        expect.objectContaining({ pluginResult }),
+        expect.objectContaining({
+          reason: 'partialResultPreservedExistingCache',
+          cachePreserved: true,
+          existingProductCount: initialProductsInCache.length,
+          pluginResult,
+        }),
       );
       emitSpy.mockRestore();
     });
@@ -562,7 +572,12 @@ describe('user: bookings controller - searchProducts', () => {
       }));
       expect(fakePlugin.events.emit).toHaveBeenCalledWith(
         'bookingsProductSearch:cache:emptyRefreshSkipped',
-        expect.objectContaining({ pluginResult }),
+        expect.objectContaining({
+          reason: 'emptyResultPreservedConcurrentCache',
+          cachePreserved: true,
+          existingProductCount: 1,
+          pluginResult,
+        }),
       );
     });
   });

--- a/controllers/__tests__/bookings-searchProducts.js
+++ b/controllers/__tests__/bookings-searchProducts.js
@@ -404,6 +404,13 @@ describe('user: bookings controller - searchProducts', () => {
         value: { products: initialProductsInCache },
         ttl: 60,
       });
+      await cache.save({
+        pluginName: testAppName,
+        key: `${cacheKeyForTest}:lastUpdated`,
+        value: 1,
+        ttl: 60,
+      });
+      const emitSpy = jest.spyOn(travelgatePlugin.events, 'emit');
 
       await bookingsControllerFactory(globalPlugins).$updateProductSearchCache({
         appKey: testAppName,
@@ -414,7 +421,14 @@ describe('user: bookings controller - searchProducts', () => {
       });
 
       const cached = await cache.get({ pluginName: testAppName, key: cacheKeyForTest });
+      const lastUpdated = await cache.get({ pluginName: testAppName, key: `${cacheKeyForTest}:lastUpdated` });
       expect(cached.products).toEqual(initialProductsInCache);
+      expect(lastUpdated).toBeGreaterThan(1);
+      expect(emitSpy).toHaveBeenCalledWith(
+        'bookingsProductSearch:cache:emptyRefreshSkipped',
+        expect.objectContaining({ pluginResult: { products: [] } }),
+      );
+      emitSpy.mockRestore();
     });
 
     it('should not cache partial product refreshes as complete results', async () => {
@@ -438,6 +452,91 @@ describe('user: bookings controller - searchProducts', () => {
 
       const cached = await cache.get({ pluginName: testAppName, key: cacheKeyForTest });
       expect(cached).toBeFalsy();
+    });
+
+    it('should keep existing non-empty cache when background refresh returns partial products', async () => {
+      const initialProductsInCache = [{ productId: 'staleProd1', name: 'Stale Product One', optionId: 'optStale1' }];
+      const pluginResult = {
+        catalogPartial: true,
+        products: [{ productId: 'partialProd1' }],
+      };
+      const cacheKeyForTest = hash({
+        userId: testUserId,
+        hint: staleCacheTestHint,
+        operationId: 'bookingsProductSearch',
+      });
+      await cache.save({
+        pluginName: testAppName,
+        key: cacheKeyForTest,
+        value: { products: initialProductsInCache },
+        ttl: 60,
+      });
+      await cache.save({
+        pluginName: testAppName,
+        key: `${cacheKeyForTest}:lastUpdated`,
+        value: 1,
+        ttl: 60,
+      });
+      const emitSpy = jest.spyOn(travelgatePlugin.events, 'emit');
+
+      await bookingsControllerFactory(globalPlugins).$updateProductSearchCache({
+        appKey: testAppName,
+        userId: testUserId,
+        hint: staleCacheTestHint,
+        pluginResult,
+        requestId: 'partial-refresh-test',
+      });
+
+      const cached = await cache.get({ pluginName: testAppName, key: cacheKeyForTest });
+      const lastUpdated = await cache.get({ pluginName: testAppName, key: `${cacheKeyForTest}:lastUpdated` });
+      expect(cached.products).toEqual(initialProductsInCache);
+      expect(lastUpdated).toBeGreaterThan(1);
+      expect(emitSpy).toHaveBeenCalledWith(
+        'bookingsProductSearch:cache:partialRefreshSkipped',
+        expect.objectContaining({ pluginResult }),
+      );
+      emitSpy.mockRestore();
+    });
+
+    it('should not cache empty products if non-empty cache appears before the empty save', async () => {
+      const cacheKeyForTest = hash({
+        userId: 'race-user',
+        hint: 'race-hint',
+        operationId: 'bookingsProductSearch',
+      });
+      const pluginResult = { products: [] };
+      const fakePlugin = {
+        name: 'racePlugin',
+        cache: {
+          get: jest.fn()
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ products: [{ productId: 'raceProd1' }] }),
+          save: jest.fn(async () => {}),
+        },
+        events: {
+          emit: jest.fn(),
+        },
+      };
+
+      await bookingsControllerFactory([fakePlugin]).$updateProductSearchCache({
+        appKey: fakePlugin.name,
+        userId: 'race-user',
+        hint: 'race-hint',
+        pluginResult,
+        requestId: 'race-refresh-test',
+      });
+
+      expect(fakePlugin.cache.save).toHaveBeenCalledWith(expect.objectContaining({
+        key: `${cacheKeyForTest}:lastUpdated`,
+      }));
+      expect(fakePlugin.cache.save).not.toHaveBeenCalledWith(expect.objectContaining({
+        key: cacheKeyForTest,
+        value: { products: [] },
+      }));
+      expect(fakePlugin.events.emit).toHaveBeenCalledWith(
+        'bookingsProductSearch:cache:emptyRefreshSkipped',
+        expect.objectContaining({ pluginResult }),
+      );
     });
   });
 });

--- a/controllers/__tests__/bookings-searchProducts.js
+++ b/controllers/__tests__/bookings-searchProducts.js
@@ -456,6 +456,31 @@ describe('user: bookings controller - searchProducts', () => {
       expect(lastUpdated).toBeTruthy();
     });
 
+    it('should not update cache metadata when direct force refresh returns partial products', async () => {
+      const pluginResult = {
+        catalogPartial: true,
+        products: [{ productId: 'partialProd1' }],
+      };
+      const cacheKeyForTest = hash({
+        userId: testUserId,
+        hint: staleCacheTestHint,
+        operationId: 'bookingsProductSearch',
+      });
+      travelgatePlugin.searchProducts.mockResolvedValueOnce(pluginResult);
+
+      await doApiPost({
+        url: `/products/${testAppName}/${testUserId}/${staleCacheTestHint}/search`,
+        token: userToken,
+        payload: { forceRefresh: true },
+      });
+
+      const cached = await cache.get({ pluginName: testAppName, key: cacheKeyForTest });
+      const lastUpdated = await cache.get({ pluginName: testAppName, key: `${cacheKeyForTest}:lastUpdated` });
+      expect(travelgatePlugin.searchProducts).toHaveBeenCalledTimes(1);
+      expect(cached).toBeFalsy();
+      expect(lastUpdated).toBeFalsy();
+    });
+
     it('should keep existing non-empty cache when background refresh returns partial products', async () => {
       const initialProductsInCache = [{ productId: 'staleProd1', name: 'Stale Product One', optionId: 'optStale1' }];
       const pluginResult = {

--- a/controllers/__tests__/bookings-searchProducts.js
+++ b/controllers/__tests__/bookings-searchProducts.js
@@ -451,7 +451,9 @@ describe('user: bookings controller - searchProducts', () => {
       });
 
       const cached = await cache.get({ pluginName: testAppName, key: cacheKeyForTest });
+      const lastUpdated = await cache.get({ pluginName: testAppName, key: `${cacheKeyForTest}:lastUpdated` });
       expect(cached).toBeFalsy();
+      expect(lastUpdated).toBeTruthy();
     });
 
     it('should keep existing non-empty cache when background refresh returns partial products', async () => {

--- a/controllers/__tests__/bookings-searchProducts.js
+++ b/controllers/__tests__/bookings-searchProducts.js
@@ -3,6 +3,7 @@
 const chance = require('chance').Chance();
 const hash = require('object-hash');
 const cache = require('../../cache');
+const bookingsControllerFactory = require('../bookings');
 // Remove direct import of listJobs, jobStatus as we'll mock addJob
 // const { listJobs, jobStatus } = require('../../worker/queue');
 
@@ -387,8 +388,56 @@ describe('user: bookings controller - searchProducts', () => {
       expect(travelgatePlugin.searchProducts).not.toHaveBeenCalled();
 
       // Note: This test verifies the immediate response serves stale data and a job is queued.
-      // It does not verify the cache state *after* the job (which would use the empty refresh)
-      // because $updateProductSearchCache currently caches empty results.
+      // Cache preservation for empty background refreshes is covered below.
+    });
+
+    it('should keep existing non-empty cache when background refresh returns empty products', async () => {
+      const initialProductsInCache = [{ productId: 'staleProd1', name: 'Stale Product One', optionId: 'optStale1' }];
+      const cacheKeyForTest = hash({
+        userId: testUserId,
+        hint: staleCacheTestHint,
+        operationId: 'bookingsProductSearch',
+      });
+      await cache.save({
+        pluginName: testAppName,
+        key: cacheKeyForTest,
+        value: { products: initialProductsInCache },
+        ttl: 60,
+      });
+
+      await bookingsControllerFactory(globalPlugins).$updateProductSearchCache({
+        appKey: testAppName,
+        userId: testUserId,
+        hint: staleCacheTestHint,
+        pluginResult: { products: [] },
+        requestId: 'empty-refresh-test',
+      });
+
+      const cached = await cache.get({ pluginName: testAppName, key: cacheKeyForTest });
+      expect(cached.products).toEqual(initialProductsInCache);
+    });
+
+    it('should not cache partial product refreshes as complete results', async () => {
+      const cacheKeyForTest = hash({
+        userId: testUserId,
+        hint: staleCacheTestHint,
+        operationId: 'bookingsProductSearch',
+      });
+      await cache.drop({ pluginName: testAppName, key: cacheKeyForTest });
+
+      await bookingsControllerFactory(globalPlugins).$updateProductSearchCache({
+        appKey: testAppName,
+        userId: testUserId,
+        hint: staleCacheTestHint,
+        pluginResult: {
+          catalogPartial: true,
+          products: [{ productId: 'partialProd1' }],
+        },
+        requestId: 'partial-refresh-test',
+      });
+
+      const cached = await cache.get({ pluginName: testAppName, key: cacheKeyForTest });
+      expect(cached).toBeFalsy();
     });
   });
 });
@@ -530,4 +579,3 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
     }
   });
 });
-

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -204,7 +204,8 @@ const $bookingsProductSearch = plugins => async ({
         });
       } else if (pluginResults && (pluginResults.catalogPartial || pluginResults.partial)) {
         app.events.emit('bookingsProductSearch:cache:partialRefreshSkipped', {
-          cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name, pluginResult: pluginResults,
+          cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
+          reason: 'directPartialResultNotCached', pluginResult: pluginResults,
         });
       }
       // If pluginResults are empty, cache is NOT updated here by fetchFromPluginAndCache.
@@ -594,14 +595,23 @@ const $updateProductSearchCache = plugins => async ({
       await markRefreshAttempted();
       emitCacheEvent(
         isPartialRefresh ? 'bookingsProductSearch:cache:partialRefreshSkipped' : 'bookingsProductSearch:cache:emptyRefreshSkipped',
-        { pluginResult },
+        {
+          reason: isPartialRefresh ? 'partialResultPreservedExistingCache' : 'emptyResultPreservedExistingCache',
+          cachePreserved: true,
+          existingProductCount: existingCacheContent.products.length,
+          pluginResult,
+        },
       );
       return;
     }
 
     if (isPartialRefresh) {
       await markRefreshAttempted();
-      emitCacheEvent('bookingsProductSearch:cache:partialRefreshSkipped', { pluginResult });
+      emitCacheEvent('bookingsProductSearch:cache:partialRefreshSkipped', {
+        reason: 'partialResultNotCached',
+        cachePreserved: false,
+        pluginResult,
+      });
       return;
     }
 
@@ -609,7 +619,12 @@ const $updateProductSearchCache = plugins => async ({
     const latestCacheContent = await app.cache.get({ key: cacheKey });
     if (hasNonEmptyProductCache(latestCacheContent)) {
       await markRefreshAttempted();
-      emitCacheEvent('bookingsProductSearch:cache:emptyRefreshSkipped', { pluginResult });
+      emitCacheEvent('bookingsProductSearch:cache:emptyRefreshSkipped', {
+        reason: 'emptyResultPreservedConcurrentCache',
+        cachePreserved: true,
+        existingProductCount: latestCacheContent.products.length,
+        pluginResult,
+      });
       return;
     }
 

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -560,38 +560,52 @@ const $updateProductSearchCache = plugins => async ({
 
   const cacheKey = hash({ userId, hint, operationId: 'bookingsProductSearch' });
   const monthInSeconds = 30 * 24 * 60 * 60;
+  const markRefreshAttempted = () => app.cache.save({
+    key: `${cacheKey}:lastUpdated`,
+    value: Date.now(),
+    ttl: monthInSeconds,
+  });
+  const emitCacheEvent = (eventName, extra = {}) => app.events.emit(eventName, {
+    cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
+    ...extra,
+  });
 
   if (hasCacheableProductResults(pluginResult)) {
-    await app.cache.save({ key: `${cacheKey}:lastUpdated`, value: Date.now(), ttl: monthInSeconds });
+    await markRefreshAttempted();
     await app.cache.save({ key: cacheKey, value: pluginResult, ttl: monthInSeconds });
-    app.events.emit('bookingsProductSearch:cache:save', {
-      cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
-    });
+    emitCacheEvent('bookingsProductSearch:cache:save');
     console.log(`[$updateProductSearchCache][requestId: ${requestId}] Saved products to cache for ${appKey}, user ${userId}, hint ${hint}.`);
   } else {
+    const isPartialRefresh = pluginResult && (pluginResult.catalogPartial || pluginResult.partial);
     const existingCacheContent = await app.cache.get({ key: cacheKey });
     if (existingCacheContent && existingCacheContent.products && existingCacheContent.products.length > 0) {
-      app.events.emit('bookingsProductSearch:cache:emptyRefreshSkipped', {
-        cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
-      });
+      await markRefreshAttempted();
+      emitCacheEvent(
+        isPartialRefresh ? 'bookingsProductSearch:cache:partialRefreshSkipped' : 'bookingsProductSearch:cache:emptyRefreshSkipped',
+        { pluginResult },
+      );
       console.log(`[$updateProductSearchCache][requestId: ${requestId}] Plugin returned empty/partial products. Keeping existing non-empty cache for ${appKey}, user ${userId}, hint ${hint}.`);
       return;
     }
 
-    if (pluginResult && (pluginResult.catalogPartial || pluginResult.partial)) {
-      app.events.emit('bookingsProductSearch:cache:partialRefreshSkipped', {
-        cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
-      });
+    if (isPartialRefresh) {
+      emitCacheEvent('bookingsProductSearch:cache:partialRefreshSkipped', { pluginResult });
       console.log(`[$updateProductSearchCache][requestId: ${requestId}] Plugin returned partial products. Cache not updated for ${appKey}, user ${userId}, hint ${hint}.`);
       return;
     }
 
+    const latestCacheContent = await app.cache.get({ key: cacheKey });
+    if (latestCacheContent && latestCacheContent.products && latestCacheContent.products.length > 0) {
+      await markRefreshAttempted();
+      emitCacheEvent('bookingsProductSearch:cache:emptyRefreshSkipped', { pluginResult });
+      console.log(`[$updateProductSearchCache][requestId: ${requestId}] Plugin returned empty/no products, but cache was refreshed by another worker. Keeping existing non-empty cache for ${appKey}, user ${userId}, hint ${hint}.`);
+      return;
+    }
+
     // Empty complete refreshes are authoritative only when there is no existing non-empty cache.
-    await app.cache.save({ key: `${cacheKey}:lastUpdated`, value: Date.now(), ttl: monthInSeconds });
+    await markRefreshAttempted();
     await app.cache.save({ key: cacheKey, value: { products: [] }, ttl: monthInSeconds });
-    app.events.emit('bookingsProductSearch:cache:emptyRefresh', {
-      cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
-    });
+    emitCacheEvent('bookingsProductSearch:cache:emptyRefresh', { pluginResult });
     console.log(`[$updateProductSearchCache][requestId: ${requestId}] Plugin returned empty/no products. Cached empty for ${appKey}, user ${userId}, hint ${hint}.`);
   }
 };

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -123,6 +123,14 @@ const $searchProductList = (products, searchInput = '', optionId = '') => {
   return filteredProducts;
 };
 
+const hasCacheableProductResults = pluginResults => Boolean(
+  pluginResults
+  && pluginResults.products
+  && pluginResults.products.length > 0
+  && !pluginResults.catalogPartial
+  && !pluginResults.partial
+);
+
 const $bookingsProductSearch = plugins => async ({
   axios,
   appKey,
@@ -179,7 +187,7 @@ const $bookingsProductSearch = plugins => async ({
       // This function is responsible for caching if it fetched good results.
       // This applies to forceRefresh, initial load, or direct calls that result in a fetch.
       // The $updateProductSearchCache function handles caching for background jobs queued due to stale data.
-      if (pluginResults && pluginResults.products && pluginResults.products.length > 0) {
+      if (hasCacheableProductResults(pluginResults)) {
         const monthInSeconds = 30 * 24 * 60 * 60;
         await app.cache.save({ key: `${cacheKey}:lastUpdated`, value: Date.now(), ttl: monthInSeconds });
         await app.cache.save({ key: cacheKey, value: pluginResults, ttl: monthInSeconds });
@@ -553,23 +561,36 @@ const $updateProductSearchCache = plugins => async ({
   const cacheKey = hash({ userId, hint, operationId: 'bookingsProductSearch' });
   const monthInSeconds = 30 * 24 * 60 * 60;
 
-  // Always update lastUpdated to prevent immediate re-trigger of background jobs
-  // even if the plugin returned empty results.
-  await app.cache.save({ key: `${cacheKey}:lastUpdated`, value: Date.now(), ttl: monthInSeconds });
-
-  if (pluginResult && pluginResult.products && pluginResult.products.length > 0) {
+  if (hasCacheableProductResults(pluginResult)) {
+    await app.cache.save({ key: `${cacheKey}:lastUpdated`, value: Date.now(), ttl: monthInSeconds });
     await app.cache.save({ key: cacheKey, value: pluginResult, ttl: monthInSeconds });
     app.events.emit('bookingsProductSearch:cache:save', {
       cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
     });
     console.log(`[$updateProductSearchCache][requestId: ${requestId}] Saved products to cache for ${appKey}, user ${userId}, hint ${hint}.`);
   } else {
-    // If plugin returned no products, update the cache to reflect this.
-    // This prevents serving stale data indefinitely if the source truly has no products anymore.
+    const existingCacheContent = await app.cache.get({ key: cacheKey });
+    if (existingCacheContent && existingCacheContent.products && existingCacheContent.products.length > 0) {
+      app.events.emit('bookingsProductSearch:cache:emptyRefreshSkipped', {
+        cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
+      });
+      console.log(`[$updateProductSearchCache][requestId: ${requestId}] Plugin returned empty/partial products. Keeping existing non-empty cache for ${appKey}, user ${userId}, hint ${hint}.`);
+      return;
+    }
+
+    if (pluginResult && (pluginResult.catalogPartial || pluginResult.partial)) {
+      app.events.emit('bookingsProductSearch:cache:partialRefreshSkipped', {
+        cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
+      });
+      console.log(`[$updateProductSearchCache][requestId: ${requestId}] Plugin returned partial products. Cache not updated for ${appKey}, user ${userId}, hint ${hint}.`);
+      return;
+    }
+
+    // Empty complete refreshes are authoritative only when there is no existing non-empty cache.
+    await app.cache.save({ key: `${cacheKey}:lastUpdated`, value: Date.now(), ttl: monthInSeconds });
     await app.cache.save({ key: cacheKey, value: { products: [] }, ttl: monthInSeconds });
     app.events.emit('bookingsProductSearch:cache:emptyRefresh', {
       cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
-      pluginResult, // Log what the plugin returned
     });
     console.log(`[$updateProductSearchCache][requestId: ${requestId}] Plugin returned empty/no products. Cached empty for ${appKey}, user ${userId}, hint ${hint}.`);
   }

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -133,6 +133,12 @@ const hasCacheableProductResults = pluginResults => Boolean(
   && !pluginResults.partial
 );
 
+const hasNonEmptyProductCache = cacheContent => Boolean(
+  cacheContent
+  && cacheContent.products
+  && cacheContent.products.length > 0
+);
+
 const $bookingsProductSearch = plugins => async ({
   axios,
   appKey,
@@ -584,7 +590,7 @@ const $updateProductSearchCache = plugins => async ({
   } else {
     const isPartialRefresh = pluginResult && (pluginResult.catalogPartial || pluginResult.partial);
     const existingCacheContent = await app.cache.get({ key: cacheKey });
-    if (existingCacheContent && existingCacheContent.products && existingCacheContent.products.length > 0) {
+    if (hasNonEmptyProductCache(existingCacheContent)) {
       await markRefreshAttempted();
       emitCacheEvent(
         isPartialRefresh ? 'bookingsProductSearch:cache:partialRefreshSkipped' : 'bookingsProductSearch:cache:emptyRefreshSkipped',
@@ -603,7 +609,7 @@ const $updateProductSearchCache = plugins => async ({
 
     // Best-effort race guard: avoid overwriting a non-empty cache written after the first read.
     const latestCacheContent = await app.cache.get({ key: cacheKey });
-    if (latestCacheContent && latestCacheContent.products && latestCacheContent.products.length > 0) {
+    if (hasNonEmptyProductCache(latestCacheContent)) {
       await markRefreshAttempted();
       emitCacheEvent('bookingsProductSearch:cache:emptyRefreshSkipped', { pluginResult });
       console.log(`[$updateProductSearchCache][requestId: ${requestId}] Plugin returned empty/no products, but cache was refreshed by another worker. Keeping existing non-empty cache for ${appKey}, user ${userId}, hint ${hint}.`);

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -196,6 +196,12 @@ const $bookingsProductSearch = plugins => async ({
         app.events.emit('bookingsProductSearch:cache:save', {
           cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
         });
+      } else if (pluginResults && (pluginResults.catalogPartial || pluginResults.partial)) {
+        const monthInSeconds = 30 * 24 * 60 * 60;
+        await app.cache.save({ key: `${cacheKey}:lastUpdated`, value: Date.now(), ttl: monthInSeconds });
+        app.events.emit('bookingsProductSearch:cache:partialRefreshSkipped', {
+          cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name, pluginResult: pluginResults,
+        });
       }
       // If pluginResults are empty, cache is NOT updated here by fetchFromPluginAndCache.
       // This maintains existing behavior for forceRefresh/initial load paths.

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -123,6 +123,8 @@ const $searchProductList = (products, searchInput = '', optionId = '') => {
   return filteredProducts;
 };
 
+// Plugins may flag incomplete catalog responses with `catalogPartial` or `partial`;
+// both must suppress cache writes so a partial result does not replace a complete cache.
 const hasCacheableProductResults = pluginResults => Boolean(
   pluginResults
   && pluginResults.products
@@ -589,6 +591,7 @@ const $updateProductSearchCache = plugins => async ({
     }
 
     if (isPartialRefresh) {
+      await markRefreshAttempted();
       emitCacheEvent('bookingsProductSearch:cache:partialRefreshSkipped', { pluginResult });
       console.log(`[$updateProductSearchCache][requestId: ${requestId}] Plugin returned partial products. Cache not updated for ${appKey}, user ${userId}, hint ${hint}.`);
       return;

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -596,14 +596,12 @@ const $updateProductSearchCache = plugins => async ({
         isPartialRefresh ? 'bookingsProductSearch:cache:partialRefreshSkipped' : 'bookingsProductSearch:cache:emptyRefreshSkipped',
         { pluginResult },
       );
-      console.log(`[$updateProductSearchCache][requestId: ${requestId}] Plugin returned empty/partial products. Keeping existing non-empty cache for ${appKey}, user ${userId}, hint ${hint}.`);
       return;
     }
 
     if (isPartialRefresh) {
       await markRefreshAttempted();
       emitCacheEvent('bookingsProductSearch:cache:partialRefreshSkipped', { pluginResult });
-      console.log(`[$updateProductSearchCache][requestId: ${requestId}] Plugin returned partial products. Cache not updated for ${appKey}, user ${userId}, hint ${hint}.`);
       return;
     }
 
@@ -612,7 +610,6 @@ const $updateProductSearchCache = plugins => async ({
     if (hasNonEmptyProductCache(latestCacheContent)) {
       await markRefreshAttempted();
       emitCacheEvent('bookingsProductSearch:cache:emptyRefreshSkipped', { pluginResult });
-      console.log(`[$updateProductSearchCache][requestId: ${requestId}] Plugin returned empty/no products, but cache was refreshed by another worker. Keeping existing non-empty cache for ${appKey}, user ${userId}, hint ${hint}.`);
       return;
     }
 

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -197,8 +197,6 @@ const $bookingsProductSearch = plugins => async ({
           cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
         });
       } else if (pluginResults && (pluginResults.catalogPartial || pluginResults.partial)) {
-        const monthInSeconds = 30 * 24 * 60 * 60;
-        await app.cache.save({ key: `${cacheKey}:lastUpdated`, value: Date.now(), ttl: monthInSeconds });
         app.events.emit('bookingsProductSearch:cache:partialRefreshSkipped', {
           cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name, pluginResult: pluginResults,
         });
@@ -603,6 +601,7 @@ const $updateProductSearchCache = plugins => async ({
       return;
     }
 
+    // Best-effort race guard: avoid overwriting a non-empty cache written after the first read.
     const latestCacheContent = await app.cache.get({ key: cacheKey });
     if (latestCacheContent && latestCacheContent.products && latestCacheContent.products.length > 0) {
       await markRefreshAttempted();

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -587,7 +587,6 @@ const $updateProductSearchCache = plugins => async ({
     await markRefreshAttempted();
     await app.cache.save({ key: cacheKey, value: pluginResult, ttl: monthInSeconds });
     emitCacheEvent('bookingsProductSearch:cache:save');
-    console.log(`[$updateProductSearchCache][requestId: ${requestId}] Saved products to cache for ${appKey}, user ${userId}, hint ${hint}.`);
   } else {
     const isPartialRefresh = pluginResult && (pluginResult.catalogPartial || pluginResult.partial);
     const existingCacheContent = await app.cache.get({ key: cacheKey });
@@ -632,7 +631,6 @@ const $updateProductSearchCache = plugins => async ({
     await markRefreshAttempted();
     await app.cache.save({ key: cacheKey, value: { products: [] }, ttl: monthInSeconds });
     emitCacheEvent('bookingsProductSearch:cache:emptyRefresh', { pluginResult });
-    console.log(`[$updateProductSearchCache][requestId: ${requestId}] Plugin returned empty/no products. Cached empty for ${appKey}, user ${userId}, hint ${hint}.`);
   }
 };
 


### PR DESCRIPTION
## Summary
- require product refresh results to be cacheable before replacing product-search cache entries
- preserve existing non-empty product-search cache entries when background refreshes return empty or partial catalogs
- cover stale-cache, empty-refresh, and partial-refresh behavior in controller tests

## Validation
- `npm test -- controllers/__tests__/bookings-searchProducts.js --forceExit`
- `git diff --check`
