### PR TITLE
Add product search cache decision telemetry

### DIFF
--- a/__tests__/cache.js
+++ b/__tests__/cache.js
@@ -39,6 +39,46 @@ describe('cache', () => {
     });
   });
 
+  describe('owner-token helpers', () => {
+    it('should only renew and drop a key when the expected value still owns it', async () => {
+      const key = 'owner-lock:test';
+      testKeys.push(key);
+
+      await cache.save({ pluginName: testPluginName, key, value: 'owner-a', ttl: 1 });
+
+      const renewedByWrongOwner = await cache.expireIfValue({
+        pluginName: testPluginName,
+        key,
+        value: 'owner-b',
+        ttl: 60,
+      });
+      const renewedByOwner = await cache.expireIfValue({
+        pluginName: testPluginName,
+        key,
+        value: 'owner-a',
+        ttl: 60,
+      });
+      const droppedByWrongOwner = await cache.dropIfValue({
+        pluginName: testPluginName,
+        key,
+        value: 'owner-b',
+      });
+
+      expect(renewedByWrongOwner).toBe(false);
+      expect(renewedByOwner).toBe(true);
+      expect(droppedByWrongOwner).toBe(false);
+      expect(await cache.get({ pluginName: testPluginName, key })).toBe('owner-a');
+
+      const droppedByOwner = await cache.dropIfValue({
+        pluginName: testPluginName,
+        key,
+        value: 'owner-a',
+      });
+      expect(droppedByOwner).toBe(true);
+      expect(await cache.get({ pluginName: testPluginName, key })).toBeFalsy();
+    });
+  });
+
   describe('scan', () => {
     it('should return keys matching the pattern without plugin prefix', async () => {
       // Save some test keys

--- a/cache.js
+++ b/cache.js
@@ -48,6 +48,39 @@ const saveIfNotExists = async ({
   return result === 'OK';
 };
 
+const expireIfValue = async ({
+  pluginName,
+  key: keyParam,
+  value,
+  ttl = defaultTTL,
+}) => {
+  const key = buildKey({ pluginName, key: keyParam });
+  const expectedValue = JSON.stringify(value);
+  const result = await cache.eval(`
+    if redis.call('get', KEYS[1]) == ARGV[1] then
+      return redis.call('expire', KEYS[1], ARGV[2])
+    end
+    return 0
+  `, 1, key, expectedValue, ttl);
+  return result === 1;
+};
+
+const dropIfValue = async ({
+  pluginName,
+  key: keyParam,
+  value,
+}) => {
+  const key = buildKey({ pluginName, key: keyParam });
+  const expectedValue = JSON.stringify(value);
+  const result = await cache.eval(`
+    if redis.call('get', KEYS[1]) == ARGV[1] then
+      return redis.call('del', KEYS[1])
+    end
+    return 0
+  `, 1, key, expectedValue);
+  return result === 1;
+};
+
 const get = async ({
   pluginName,
   key: keyParam,
@@ -125,6 +158,8 @@ module.exports = {
   cache,
   save,
   saveIfNotExists,
+  expireIfValue,
+  dropIfValue,
   getOrExec,
   drop,
   get,

--- a/controllers/__tests__/bookings-searchProducts.js
+++ b/controllers/__tests__/bookings-searchProducts.js
@@ -9,7 +9,7 @@ const cache = require('../../cache');
 // Mock the worker/queue module
 jest.mock('../../worker/queue', () => ({
   ...jest.requireActual('../../worker/queue'), // Import and retain default behavior
-  addJob: jest.fn().mockResolvedValue({ id: 'mockJobId' }), // Mock addJob
+  addJob: jest.fn().mockResolvedValue('mockJobId'), // Mock addJob
   // Provide mock for jobStatus as it might be called by other parts of the code or tests
   jobStatus: jest.fn().mockResolvedValue({ status: 'completed', progress: 100, returnValue: null }),
 }));
@@ -298,6 +298,7 @@ describe('user: bookings controller - searchProducts', () => {
         it('call outside of TTR should serve stale data and queue background refresh with correct parameters', async () => {
           travelgatePlugin.searchProducts.mockClear(); // Clear before action
           addJob.mockClear(); // Clear addJob mock before this action that should trigger it
+          const emitSpy = jest.spyOn(travelgatePlugin.events, 'emit');
 
           const { products } = await doApiPost({
             url: `/products/${testAppName}/${testUserId}/${ttrTestHint}/search`, // appName is 'travelgate'
@@ -331,6 +332,15 @@ describe('user: bookings controller - searchProducts', () => {
           expect(jobData.postProcess.args.userId).toBe(testUserId);
           expect(jobData.postProcess.args.hint).toBe(ttrTestHint);
           expect(jobParams).toEqual({ removeOnComplete: true });
+          expect(emitSpy).toHaveBeenCalledWith(
+            'bookingsProductSearch:cache:decision',
+            expect.objectContaining({
+              action: 'stale_served',
+              reason: 'backgroundRefreshQueued',
+              jobId: 'mockJobId',
+            }),
+          );
+          emitSpy.mockRestore();
         });
       });
       // The 'lock mechanism (job queuing on stale cache)' describe block has been moved to the top level.
@@ -476,6 +486,14 @@ describe('user: bookings controller - searchProducts', () => {
           existingProductCount: initialProductsInCache.length,
         }),
       );
+      expect(emitSpy).toHaveBeenCalledWith(
+        'bookingsProductSearch:cache:emptyRefreshSkipped',
+        expect.objectContaining({
+          action: 'empty_refresh_skipped',
+          reason: 'emptyResultPreservedExistingCache',
+          cachePreserved: true,
+        }),
+      );
       emitSpy.mockRestore();
     });
 
@@ -576,6 +594,14 @@ describe('user: bookings controller - searchProducts', () => {
           returnedProductCount: pluginResult.products.length,
         }),
       );
+      expect(emitSpy).toHaveBeenCalledWith(
+        'bookingsProductSearch:cache:partialRefreshSkipped',
+        expect.objectContaining({
+          action: 'partial_refresh_skipped',
+          reason: 'partialResultPreservedExistingCache',
+          cachePreserved: true,
+        }),
+      );
       emitSpy.mockRestore();
     });
 
@@ -621,6 +647,14 @@ describe('user: bookings controller - searchProducts', () => {
           reason: 'emptyResultPreservedConcurrentCache',
           cachePreserved: true,
           existingProductCount: 1,
+        }),
+      );
+      expect(fakePlugin.events.emit).toHaveBeenCalledWith(
+        'bookingsProductSearch:cache:emptyRefreshSkipped',
+        expect.objectContaining({
+          action: 'empty_refresh_skipped',
+          reason: 'emptyResultPreservedConcurrentCache',
+          cachePreserved: true,
         }),
       );
     });
@@ -861,6 +895,8 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
 
   it('renews the plugin execution lock while a cold product fetch exceeds the initial TTL', async () => {
     await clearProductSearchCache();
+    const originalLockTtl = process.env.PRODUCT_SEARCH_LOCK_TTL_SECONDS;
+    process.env.PRODUCT_SEARCH_LOCK_TTL_SECONDS = '1';
 
     const slowProducts = [{
       productId: 'slow-product',
@@ -871,6 +907,7 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
       }],
     }];
     lockTestPlugin.searchProducts.mockReset();
+    const expireIfValueSpy = jest.spyOn(lockTestPlugin.cache, 'expireIfValue');
     const releasePluginFetches = [];
     const pluginFetchStarted = new Promise(resolve => {
       lockTestPlugin.searchProducts.mockImplementation(() => {
@@ -881,20 +918,30 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
       });
     });
 
-    const firstRequest = makeProductSearchRequest();
-    await pluginFetchStarted;
-    await new Promise(resolve => setTimeout(resolve, 1500));
-    const secondRequest = makeProductSearchRequest();
-    await new Promise(resolve => setTimeout(resolve, 50));
+    try {
+      const firstRequest = makeProductSearchRequest();
+      await pluginFetchStarted;
+      await new Promise(resolve => setTimeout(resolve, 1500));
+      const secondRequest = makeProductSearchRequest();
+      await new Promise(resolve => setTimeout(resolve, 50));
 
-    releasePluginFetches.forEach(releasePluginFetch => releasePluginFetch());
-    const results = await Promise.all([firstRequest, secondRequest]);
+      releasePluginFetches.forEach(releasePluginFetch => releasePluginFetch());
+      const results = await Promise.all([firstRequest, secondRequest]);
 
-    results.forEach(result => {
-      expect(result.products).toEqual(slowProducts);
-    });
-    expect(lockTestPlugin.searchProducts).toHaveBeenCalledTimes(1);
-    expect(addJob).not.toHaveBeenCalled();
+      results.forEach(result => {
+        expect(result.products).toEqual(slowProducts);
+      });
+      expect(lockTestPlugin.searchProducts).toHaveBeenCalledTimes(1);
+      expect(addJob).not.toHaveBeenCalled();
+      expect(expireIfValueSpy).toHaveBeenCalled();
+    } finally {
+      expireIfValueSpy.mockRestore();
+      if (originalLockTtl === undefined) {
+        delete process.env.PRODUCT_SEARCH_LOCK_TTL_SECONDS;
+      } else {
+        process.env.PRODUCT_SEARCH_LOCK_TTL_SECONDS = originalLockTtl;
+      }
+    }
   });
 
   it('multiple concurrent requests with no cache should share an empty plugin result', async () => {

--- a/controllers/__tests__/bookings-searchProducts.js
+++ b/controllers/__tests__/bookings-searchProducts.js
@@ -160,6 +160,44 @@ describe('user: bookings controller - searchProducts', () => {
         expect(products[0].options.length).toBe(1);
         expect(products[0].options[0].optionName).toBe('Transfer from Sydney Harbor Bridge to Hilton Hotel');
       });
+      it('should filter cached full catalog by optionId without another plugin call', async () => {
+        const { products } = await doApiPost({
+          url: `/products/${testAppName}/${testUserId}/${testHint}/search`,
+          token: userToken,
+          payload: { optionId: '2345' },
+        });
+        expect(travelgatePlugin.searchProducts).not.toHaveBeenCalled();
+        expect(products).toHaveLength(1);
+        expect(products[0].options).toHaveLength(1);
+        expect(products[0].options[0].optionId).toBe('2345');
+      });
+      it('should emit sanitized cache-decision telemetry without raw ids, hints, payloads, or plugin results', async () => {
+        const emitSpy = jest.spyOn(travelgatePlugin.events, 'emit');
+        await doApiPost({
+          url: `/products/${testAppName}/${testUserId}/${testHint}/search`,
+          token: userToken,
+          payload: { searchInput: 'Transfer from Sydney Harbor to Hilton Hotel' },
+        });
+        const decisionPayloads = emitSpy.mock.calls
+          .filter(call => call[0] === 'bookingsProductSearch:cache:decision')
+          .map(call => call[1]);
+        expect(decisionPayloads.length).toBeGreaterThan(0);
+        decisionPayloads.forEach(payload => {
+          expect(payload.userId).toBeUndefined();
+          expect(payload.hint).toBeUndefined();
+          expect(payload.cacheKey).toBeUndefined();
+          expect(payload.pluginResult).toBeUndefined();
+          expect(payload.searchInput).toBeUndefined();
+          expect(payload.optionId).toBeUndefined();
+          expect(payload.userIdHash).toBeTruthy();
+          expect(payload.hintHash).toBeTruthy();
+          expect(payload.cacheKeyHash).toBeTruthy();
+          expect(JSON.stringify(payload)).not.toContain(testUserId);
+          expect(JSON.stringify(payload)).not.toContain(testHint);
+          expect(JSON.stringify(payload)).not.toContain('Transfer from Sydney Harbor');
+        });
+        emitSpy.mockRestore();
+      });
     });
     describe('doNotCallPluginForProducts flag', () => {
       const doNotCallHint = 'hint_for_doNotCallPluginForProducts';
@@ -430,8 +468,9 @@ describe('user: bookings controller - searchProducts', () => {
       expect(cached.products).toEqual(initialProductsInCache);
       expect(lastUpdated).toBeGreaterThan(1);
       expect(emitSpy).toHaveBeenCalledWith(
-        'bookingsProductSearch:cache:emptyRefreshSkipped',
+        'bookingsProductSearch:cache:decision',
         expect.objectContaining({
+          action: 'empty_refresh_skipped',
           reason: 'emptyResultPreservedExistingCache',
           cachePreserved: true,
           existingProductCount: initialProductsInCache.length,
@@ -528,12 +567,13 @@ describe('user: bookings controller - searchProducts', () => {
       expect(cached.products).toEqual(initialProductsInCache);
       expect(lastUpdated).toBeGreaterThan(1);
       expect(emitSpy).toHaveBeenCalledWith(
-        'bookingsProductSearch:cache:partialRefreshSkipped',
+        'bookingsProductSearch:cache:decision',
         expect.objectContaining({
+          action: 'partial_refresh_skipped',
           reason: 'partialResultPreservedExistingCache',
           cachePreserved: true,
           existingProductCount: initialProductsInCache.length,
-          pluginResult,
+          returnedProductCount: pluginResult.products.length,
         }),
       );
       emitSpy.mockRestore();
@@ -575,8 +615,9 @@ describe('user: bookings controller - searchProducts', () => {
         value: { products: [] },
       }));
       expect(fakePlugin.events.emit).toHaveBeenCalledWith(
-        'bookingsProductSearch:cache:emptyRefreshSkipped',
+        'bookingsProductSearch:cache:decision',
         expect.objectContaining({
+          action: 'empty_refresh_skipped',
           reason: 'emptyResultPreservedConcurrentCache',
           cachePreserved: true,
           existingProductCount: 1,
@@ -772,6 +813,85 @@ describe('Bookings Product Search Lock Mechanism (Job Queuing on Stale Cache)', 
 
     results.forEach(result => {
       expect(result.products).toEqual(coldProducts);
+    });
+    expect(lockTestPlugin.searchProducts).toHaveBeenCalledTimes(1);
+    expect(addJob).not.toHaveBeenCalled();
+  });
+
+  it('concurrent forceRefresh requests should wait for one plugin fetch', async () => {
+    await clearProductSearchCache();
+
+    const refreshedProducts = [{
+      productId: 'force-product',
+      productName: 'Force Product',
+      options: [{
+        optionId: 'force-option',
+        optionName: 'Force Option',
+      }],
+    }];
+    lockTestPlugin.searchProducts.mockReset();
+    const releasePluginFetches = [];
+    const pluginFetchStarted = new Promise(resolve => {
+      lockTestPlugin.searchProducts.mockImplementation(() => {
+        resolve();
+        return new Promise(pluginResolve => {
+          releasePluginFetches.push(() => pluginResolve({ products: refreshedProducts }));
+        });
+      });
+    });
+    const makeForceRequest = () => doApiPost({
+      url: `/products/${testAppName}/${testUserId}/${ttrTestHint}/search`,
+      token: userToken,
+      payload: { forceRefresh: true },
+    });
+
+    const requestPromises = [makeForceRequest(), makeForceRequest(), makeForceRequest()];
+    await pluginFetchStarted;
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    releasePluginFetches.forEach(releasePluginFetch => releasePluginFetch());
+    const results = await Promise.all(requestPromises);
+
+    results.forEach(result => {
+      expect(result.products).toEqual(refreshedProducts);
+    });
+    expect(lockTestPlugin.searchProducts).toHaveBeenCalledTimes(1);
+    expect(addJob).not.toHaveBeenCalled();
+  });
+
+  it('renews the plugin execution lock while a cold product fetch exceeds the initial TTL', async () => {
+    await clearProductSearchCache();
+
+    const slowProducts = [{
+      productId: 'slow-product',
+      productName: 'Slow Product',
+      options: [{
+        optionId: 'slow-option',
+        optionName: 'Slow Option',
+      }],
+    }];
+    lockTestPlugin.searchProducts.mockReset();
+    const releasePluginFetches = [];
+    const pluginFetchStarted = new Promise(resolve => {
+      lockTestPlugin.searchProducts.mockImplementation(() => {
+        resolve();
+        return new Promise(pluginResolve => {
+          releasePluginFetches.push(() => pluginResolve({ products: slowProducts }));
+        });
+      });
+    });
+
+    const firstRequest = makeProductSearchRequest();
+    await pluginFetchStarted;
+    await new Promise(resolve => setTimeout(resolve, 1500));
+    const secondRequest = makeProductSearchRequest();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    releasePluginFetches.forEach(releasePluginFetch => releasePluginFetch());
+    const results = await Promise.all([firstRequest, secondRequest]);
+
+    results.forEach(result => {
+      expect(result.products).toEqual(slowProducts);
     });
     expect(lockTestPlugin.searchProducts).toHaveBeenCalledTimes(1);
     expect(addJob).not.toHaveBeenCalled();

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -35,12 +35,18 @@ const getPositiveIntegerEnv = (name, defaultValue) => {
   return Number.isFinite(value) && integerValue > 0 ? integerValue : defaultValue;
 };
 
-const productSearchLockTtlSeconds = getPositiveIntegerEnv('PRODUCT_SEARCH_LOCK_TTL_SECONDS', 120);
+const getProductSearchLockTtlSeconds = () => getPositiveIntegerEnv('PRODUCT_SEARCH_LOCK_TTL_SECONDS', 120);
 const productSearchLockWaitMs = getPositiveIntegerEnv('PRODUCT_SEARCH_LOCK_WAIT_MS', 25 * 1000);
 const productSearchLockPollMs = getPositiveIntegerEnv('PRODUCT_SEARCH_LOCK_POLL_MS', 250);
 const emptyProductSearchCacheTtlSeconds = 60;
 const productSearchOperationId = 'bookingsProductSearch';
 const productSearchCacheDecisionEvent = 'bookingsProductSearch:cache:decision';
+const legacyProductSearchCacheEvents = {
+  cache_saved: 'bookingsProductSearch:cache:save',
+  partial_refresh_skipped: 'bookingsProductSearch:cache:partialRefreshSkipped',
+  empty_refresh_skipped: 'bookingsProductSearch:cache:emptyRefreshSkipped',
+  empty_cache_saved: 'bookingsProductSearch:cache:emptyRefresh',
+};
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const productCount = value => R.pathOr([], ['products'], value).length;
@@ -49,7 +55,7 @@ const safeHash = value => (value === undefined || value === null ? undefined : h
 
 const emitProductSearchCacheDecision = ({ app, cacheKey, userId, hint, requestId, searchInput, optionId, forceRefresh, startedAt }, action, extra = {}) => {
   if (!app.events || !app.events.emit) return;
-  app.events.emit(productSearchCacheDecisionEvent, {
+  const payload = {
     action,
     operationId: productSearchOperationId,
     requestId,
@@ -62,7 +68,11 @@ const emitProductSearchCacheDecision = ({ app, cacheKey, userId, hint, requestId
     hasOptionId: Boolean(optionId && optionId.length),
     elapsedMs: Date.now() - startedAt,
     ...extra,
-  });
+  };
+  app.events.emit(productSearchCacheDecisionEvent, payload);
+  if (legacyProductSearchCacheEvents[action]) {
+    app.events.emit(legacyProductSearchCacheEvents[action], payload);
+  }
 };
 
 const createLockRenewal = ({ app, key, value, ttl, onDecision }) => {
@@ -294,7 +304,7 @@ const $bookingsProductSearch = plugins => async ({
   const acquirePluginExecutionLock = async lockOwnerToken => app.cache.saveIfNotExists({
     key: pluginExecutionLockKey,
     value: lockOwnerToken,
-    ttl: productSearchLockTtlSeconds,
+    ttl: getProductSearchLockTtlSeconds(),
   });
 
   // Helper function to call the plugin, save cache, and return results
@@ -318,12 +328,13 @@ const $bookingsProductSearch = plugins => async ({
       throw createProductSearchUnavailableError();
     }
 
-    emitDecision('lock_acquired', { reason, lockTtlSeconds: productSearchLockTtlSeconds });
+    const lockTtlSeconds = getProductSearchLockTtlSeconds();
+    emitDecision('lock_acquired', { reason, lockTtlSeconds });
     const lockRenewal = createLockRenewal({
       app,
       key: pluginExecutionLockKey,
       value: lockOwnerToken,
-      ttl: productSearchLockTtlSeconds,
+      ttl: lockTtlSeconds,
       onDecision: emitDecision,
     });
 
@@ -442,7 +453,7 @@ const $bookingsProductSearch = plugins => async ({
         return returnCachedResults('stale_served', { reason: 'backgroundRefreshDeduped' });
       }
 
-      const job = await addJob({
+      const jobId = await addJob({
         type: 'plugin',
         pluginName: appKey,
         method: app.searchProducts ? 'searchProducts' : 'searchProductsForItinerary',
@@ -457,7 +468,7 @@ const $bookingsProductSearch = plugins => async ({
 
       return returnCachedResults('stale_served', {
         reason: 'backgroundRefreshQueued',
-        jobId: job && job.id,
+        jobId,
       });
     }
   }

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -39,6 +39,7 @@ const getProductSearchLockTtlSeconds = () => getPositiveIntegerEnv('PRODUCT_SEAR
 const productSearchLockWaitMs = getPositiveIntegerEnv('PRODUCT_SEARCH_LOCK_WAIT_MS', 25 * 1000);
 const productSearchLockPollMs = getPositiveIntegerEnv('PRODUCT_SEARCH_LOCK_POLL_MS', 250);
 const emptyProductSearchCacheTtlSeconds = 60;
+const productSearchCacheTtlSeconds = 30 * 24 * 60 * 60;
 const productSearchOperationId = 'bookingsProductSearch';
 const productSearchCacheDecisionEvent = 'bookingsProductSearch:cache:decision';
 const legacyProductSearchCacheEvents = {
@@ -49,7 +50,11 @@ const legacyProductSearchCacheEvents = {
 };
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
+const productSearchCacheKey = ({ userId, hint }) => hash({ userId, hint, operationId: productSearchOperationId });
+
 const productCount = value => R.pathOr([], ['products'], value).length;
+
+const hasProductCache = cacheContent => Boolean(cacheContent && cacheContent.products);
 
 const safeHash = value => (value === undefined || value === null ? undefined : hash(String(value)));
 
@@ -249,7 +254,7 @@ const $bookingsProductSearch = plugins => async ({
   assert(app.searchProducts || app.searchProductsForItinerary, `searchProducts or searchProductsForItinerary is not available for ${appKey}`);
   const func = (app.searchProducts || app.searchProductsForItinerary).bind(app);
 
-  const cacheKey = hash({ userId, hint, operationId: productSearchOperationId });
+  const cacheKey = productSearchCacheKey({ userId, hint });
   const telemetryContext = {
     app,
     cacheKey,
@@ -272,7 +277,7 @@ const $bookingsProductSearch = plugins => async ({
   const isStaleByTTR = lastUpdated && (Date.now() - lastUpdated > ttr * 1000);
   const doNotCallPluginForProducts = token.doNotCallPluginForProducts || R.path(['cacheSettings', 'bookingsProductSearch', 'doNotCall'], app);
   const hasPluginExecutionLock = await app.cache.get({ key: pluginExecutionLockKey });
-  emitDecision(initialActualCacheContent && initialActualCacheContent.products ? 'cache_hit' : 'cache_miss', {
+  emitDecision(hasProductCache(initialActualCacheContent) ? 'cache_hit' : 'cache_miss', {
     cacheProductCount: productCount(initialActualCacheContent),
     cacheAgeMs: lastUpdated ? Date.now() - lastUpdated : undefined,
     ttrMs: ttr * 1000,
@@ -282,7 +287,7 @@ const $bookingsProductSearch = plugins => async ({
 
   const getCachedProductSearchResults = async () => {
     const cacheContent = await app.cache.get({ key: cacheKey });
-    if (cacheContent && cacheContent.products) return cacheContent;
+    if (hasProductCache(cacheContent)) return cacheContent;
     return null;
   };
 
@@ -356,9 +361,8 @@ const $bookingsProductSearch = plugins => async ({
       // This applies to forceRefresh, initial load, or direct calls that result in a fetch.
       // The $updateProductSearchCache function handles caching for background jobs queued due to stale data.
       if (hasCacheableProductResults(pluginResults)) {
-        const monthInSeconds = 30 * 24 * 60 * 60;
-        await app.cache.save({ key: `${cacheKey}:lastUpdated`, value: Date.now(), ttl: monthInSeconds });
-        await app.cache.save({ key: cacheKey, value: pluginResults, ttl: monthInSeconds });
+        await app.cache.save({ key: `${cacheKey}:lastUpdated`, value: Date.now(), ttl: productSearchCacheTtlSeconds });
+        await app.cache.save({ key: cacheKey, value: pluginResults, ttl: productSearchCacheTtlSeconds });
         emitDecision('cache_saved', {
           reason,
           pluginElapsedMs,
@@ -393,7 +397,7 @@ const $bookingsProductSearch = plugins => async ({
 
   // 1. `doNotCallPluginForProducts` is true, and not `forceRefresh`: Serve from cache or empty.
   if (doNotCallPluginForProducts && !forceRefresh) {
-    if (initialActualCacheContent && initialActualCacheContent.products) {
+    if (hasProductCache(initialActualCacheContent)) {
       const searchResults = $searchProductList(initialActualCacheContent.products, searchInput, optionId);
       emitDecision('cache_hit', {
         reason: 'doNotCallPluginForProducts',
@@ -416,7 +420,7 @@ const $bookingsProductSearch = plugins => async ({
   }
 
   // 3. Cache exists (initialActualCacheContent) and not forceRefresh:
-  if (initialActualCacheContent && initialActualCacheContent.products) {
+  if (hasProductCache(initialActualCacheContent)) {
     const cacheIsEmpty = !initialActualCacheContent.products.length;
     const trimmedSearch = (searchInput || '').trim();
     const searchFilterIsEmpty = (!trimmedSearch || trimmedSearch === '*') && !(optionId && optionId.length);
@@ -764,12 +768,11 @@ const $updateProductSearchCache = plugins => async ({
     return; // Or throw error
   }
 
-  const cacheKey = hash({ userId, hint, operationId: productSearchOperationId });
-  const monthInSeconds = 30 * 24 * 60 * 60;
+  const cacheKey = productSearchCacheKey({ userId, hint });
   const markRefreshAttempted = () => app.cache.save({
     key: `${cacheKey}:lastUpdated`,
     value: Date.now(),
-    ttl: monthInSeconds,
+    ttl: productSearchCacheTtlSeconds,
   });
   const emitCacheEvent = (action, extra = {}) => emitProductSearchCacheDecision({
     app,
@@ -785,7 +788,7 @@ const $updateProductSearchCache = plugins => async ({
 
   if (hasCacheableProductResults(pluginResult)) {
     await markRefreshAttempted();
-    await app.cache.save({ key: cacheKey, value: pluginResult, ttl: monthInSeconds });
+    await app.cache.save({ key: cacheKey, value: pluginResult, ttl: productSearchCacheTtlSeconds });
     emitCacheEvent('cache_saved', { cacheProductCount: productCount(pluginResult) });
   } else {
     const isPartialRefresh = pluginResult && (pluginResult.catalogPartial || pluginResult.partial);
@@ -829,7 +832,7 @@ const $updateProductSearchCache = plugins => async ({
 
     // Empty complete refreshes are authoritative only when there is no existing non-empty cache.
     await markRefreshAttempted();
-    await app.cache.save({ key: cacheKey, value: { products: [] }, ttl: monthInSeconds });
+    await app.cache.save({ key: cacheKey, value: { products: [] }, ttl: productSearchCacheTtlSeconds });
     emitCacheEvent('empty_cache_saved', { cacheProductCount: 0 });
   }
 };

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const crypto = require('crypto');
 const hash = require('object-hash');
 const R = require('ramda');
 const { UserAppKey } = require('../models/index');
@@ -38,7 +39,62 @@ const productSearchLockTtlSeconds = getPositiveIntegerEnv('PRODUCT_SEARCH_LOCK_T
 const productSearchLockWaitMs = getPositiveIntegerEnv('PRODUCT_SEARCH_LOCK_WAIT_MS', 25 * 1000);
 const productSearchLockPollMs = getPositiveIntegerEnv('PRODUCT_SEARCH_LOCK_POLL_MS', 250);
 const emptyProductSearchCacheTtlSeconds = 60;
+const productSearchOperationId = 'bookingsProductSearch';
+const productSearchCacheDecisionEvent = 'bookingsProductSearch:cache:decision';
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const productCount = value => R.pathOr([], ['products'], value).length;
+
+const safeHash = value => (value === undefined || value === null ? undefined : hash(String(value)));
+
+const emitProductSearchCacheDecision = ({ app, cacheKey, userId, hint, requestId, searchInput, optionId, forceRefresh, startedAt }, action, extra = {}) => {
+  if (!app.events || !app.events.emit) return;
+  app.events.emit(productSearchCacheDecisionEvent, {
+    action,
+    operationId: productSearchOperationId,
+    requestId,
+    pluginName: app.name,
+    userIdHash: safeHash(userId),
+    hintHash: safeHash(hint),
+    cacheKeyHash: safeHash(cacheKey),
+    forceRefresh: Boolean(forceRefresh),
+    hasSearchInput: Boolean((searchInput || '').trim()),
+    hasOptionId: Boolean(optionId && optionId.length),
+    elapsedMs: Date.now() - startedAt,
+    ...extra,
+  });
+};
+
+const createLockRenewal = ({ app, key, value, ttl, onDecision }) => {
+  if (!app.cache.expireIfValue || ttl <= 0) return { stop: async () => {} };
+
+  const renewEveryMs = Math.max(250, Math.floor(ttl * 500));
+  let stopped = false;
+  let inFlightRenewal = Promise.resolve();
+  const renew = async () => {
+    if (stopped) return;
+    const renewed = await app.cache.expireIfValue({ key, value, ttl });
+    if (!renewed) {
+      stopped = true;
+      onDecision('lock_renew_lost', { reason: 'ownerTokenMismatch' });
+    }
+  };
+  const interval = setInterval(() => {
+    inFlightRenewal = renew().catch(err => {
+      stopped = true;
+      onDecision('lock_renew_failed', { reason: err.message });
+    });
+  }, renewEveryMs);
+  if (interval.unref) interval.unref();
+
+  return {
+    stop: async () => {
+      stopped = true;
+      clearInterval(interval);
+      await inFlightRenewal;
+    },
+  };
+};
 
 const createProductSearchUnavailableError = () => {
   const err = new Error('Product search cache refresh did not produce cached results');
@@ -183,7 +239,19 @@ const $bookingsProductSearch = plugins => async ({
   assert(app.searchProducts || app.searchProductsForItinerary, `searchProducts or searchProductsForItinerary is not available for ${appKey}`);
   const func = (app.searchProducts || app.searchProductsForItinerary).bind(app);
 
-  const cacheKey = hash({ userId, hint, operationId: 'bookingsProductSearch' });
+  const cacheKey = hash({ userId, hint, operationId: productSearchOperationId });
+  const telemetryContext = {
+    app,
+    cacheKey,
+    userId,
+    hint,
+    requestId,
+    searchInput,
+    optionId,
+    forceRefresh,
+    startedAt: Date.now(),
+  };
+  const emitDecision = (action, extra = {}) => emitProductSearchCacheDecision(telemetryContext, action, extra);
   const pluginExecutionLockKey = `${cacheKey}:lock`; // Lock for direct plugin execution
   const jobQueueLockKey = `${cacheKey}:jobLock`;   // Lock for preventing multiple job queues
 
@@ -194,6 +262,12 @@ const $bookingsProductSearch = plugins => async ({
   const isStaleByTTR = lastUpdated && (Date.now() - lastUpdated > ttr * 1000);
   const doNotCallPluginForProducts = token.doNotCallPluginForProducts || R.path(['cacheSettings', 'bookingsProductSearch', 'doNotCall'], app);
   const hasPluginExecutionLock = await app.cache.get({ key: pluginExecutionLockKey });
+  emitDecision(initialActualCacheContent && initialActualCacheContent.products ? 'cache_hit' : 'cache_miss', {
+    cacheProductCount: productCount(initialActualCacheContent),
+    cacheAgeMs: lastUpdated ? Date.now() - lastUpdated : undefined,
+    ttrMs: ttr * 1000,
+    reason: hasPluginExecutionLock ? 'lockActive' : undefined,
+  });
   assert(app.cache.saveIfNotExists, 'cache adapter must expose saveIfNotExists');
 
   const getCachedProductSearchResults = async () => {
@@ -217,23 +291,45 @@ const $bookingsProductSearch = plugins => async ({
     return getCachedProductSearchResults();
   };
 
-  const acquirePluginExecutionLock = async () => app.cache.saveIfNotExists({
+  const acquirePluginExecutionLock = async lockOwnerToken => app.cache.saveIfNotExists({
     key: pluginExecutionLockKey,
-    value: true,
+    value: lockOwnerToken,
     ttl: productSearchLockTtlSeconds,
   });
 
   // Helper function to call the plugin, save cache, and return results
-  const fetchFromPluginAndCache = async () => {
-    const lockAcquired = await acquirePluginExecutionLock();
+  const fetchFromPluginAndCache = async (reason = 'cache_miss') => {
+    const lockOwnerToken = crypto.randomBytes(16).toString('hex');
+    const lockStartedAt = Date.now();
+    const lockAcquired = await acquirePluginExecutionLock(lockOwnerToken);
     if (!lockAcquired) {
+      emitDecision('lock_wait', { reason, lockWaitMs: 0 });
       const cacheContent = await waitForProductSearchCache();
-      if (cacheContent) return cacheContent;
+      const lockWaitMs = Date.now() - lockStartedAt;
+      if (cacheContent) {
+        emitDecision('cache_hit', {
+          reason: 'waitedForLeader',
+          lockWaitMs,
+          cacheProductCount: productCount(cacheContent),
+        });
+        return cacheContent;
+      }
+      emitDecision('lock_timeout', { reason, lockWaitMs });
       throw createProductSearchUnavailableError();
     }
 
+    emitDecision('lock_acquired', { reason, lockTtlSeconds: productSearchLockTtlSeconds });
+    const lockRenewal = createLockRenewal({
+      app,
+      key: pluginExecutionLockKey,
+      value: lockOwnerToken,
+      ttl: productSearchLockTtlSeconds,
+      onDecision: emitDecision,
+    });
+
     let pluginResults;
     try {
+      const pluginStartedAt = Date.now();
       pluginResults = await func({
         axios,
         token,
@@ -243,6 +339,7 @@ const $bookingsProductSearch = plugins => async ({
         userId,
         hint,
       });
+      const pluginElapsedMs = Date.now() - pluginStartedAt;
 
       // This function is responsible for caching if it fetched usable results.
       // This applies to forceRefresh, initial load, or direct calls that result in a fetch.
@@ -251,20 +348,34 @@ const $bookingsProductSearch = plugins => async ({
         const monthInSeconds = 30 * 24 * 60 * 60;
         await app.cache.save({ key: `${cacheKey}:lastUpdated`, value: Date.now(), ttl: monthInSeconds });
         await app.cache.save({ key: cacheKey, value: pluginResults, ttl: monthInSeconds });
-        app.events.emit('bookingsProductSearch:cache:save', {
-          cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
+        emitDecision('cache_saved', {
+          reason,
+          pluginElapsedMs,
+          cacheProductCount: productCount(pluginResults),
         });
       } else if (pluginResults && (pluginResults.catalogPartial || pluginResults.partial)) {
-        app.events.emit('bookingsProductSearch:cache:partialRefreshSkipped', {
-          cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
-          reason: 'directPartialResultNotCached', pluginResult: pluginResults,
+        emitDecision('partial_refresh_skipped', {
+          reason: 'directPartialResultNotCached',
+          pluginElapsedMs,
+          cachePreserved: false,
+          returnedProductCount: productCount(pluginResults),
         });
       } else if (pluginResults && pluginResults.products && pluginResults.products.length === 0) {
         // Short-lived empty cache gives concurrent waiters the same answer as the lock holder.
         await app.cache.save({ key: cacheKey, value: pluginResults, ttl: emptyProductSearchCacheTtlSeconds });
+        emitDecision('empty_cache_saved', {
+          reason,
+          pluginElapsedMs,
+          cacheProductCount: 0,
+        });
       }
     } finally {
-      await app.cache.drop({ key: pluginExecutionLockKey });
+      await lockRenewal.stop();
+      if (app.cache.dropIfValue) {
+        await app.cache.dropIfValue({ key: pluginExecutionLockKey, value: lockOwnerToken });
+      } else {
+        await app.cache.drop({ key: pluginExecutionLockKey });
+      }
     }
     return pluginResults || { products: [] }; // Ensure products array exists
   };
@@ -273,15 +384,22 @@ const $bookingsProductSearch = plugins => async ({
   if (doNotCallPluginForProducts && !forceRefresh) {
     if (initialActualCacheContent && initialActualCacheContent.products) {
       const searchResults = $searchProductList(initialActualCacheContent.products, searchInput, optionId);
+      emitDecision('cache_hit', {
+        reason: 'doNotCallPluginForProducts',
+        cacheProductCount: initialActualCacheContent.products.length,
+        returnedProductCount: searchResults.length,
+      });
       return { ...initialActualCacheContent, products: searchResults, ...(token.configuration || {}) };
     }
+    emitDecision('cache_miss', { reason: 'doNotCallPluginForProducts' });
     return { products: [], ...(token.configuration || {}) };
   }
 
   // 2. `forceRefresh` is true (and not case 1): Fetch from plugin.
   //    fetchFromPluginAndCache will handle caching the new results.
   if (forceRefresh) {
-    const funcResults = await fetchFromPluginAndCache();
+    emitDecision('force_refresh');
+    const funcResults = await fetchFromPluginAndCache('force_refresh');
     const searchResults = $searchProductList(funcResults.products, searchInput, optionId);
     return { ...funcResults, products: searchResults, ...(token.configuration || {}) };
   }
@@ -295,8 +413,15 @@ const $bookingsProductSearch = plugins => async ({
     // If cache is empty and no search filter, skip to case 4 to fetch fresh data
     const shouldSkipEmptyCache = cacheIsEmpty && searchFilterIsEmpty;
     if (!shouldSkipEmptyCache) {
-      const returnCachedResults = () => {
+      const returnCachedResults = (action = 'cache_hit', extra = {}) => {
         const searchResults = $searchProductList(initialActualCacheContent.products, searchInput, optionId);
+        emitDecision(action, {
+          cacheProductCount: initialActualCacheContent.products.length,
+          returnedProductCount: searchResults.length,
+          cacheAgeMs: lastUpdated ? Date.now() - lastUpdated : undefined,
+          ttrMs: ttr * 1000,
+          ...extra,
+        });
         return { ...initialActualCacheContent, products: searchResults, ...(token.configuration || {}) };
       };
 
@@ -304,7 +429,7 @@ const $bookingsProductSearch = plugins => async ({
 
       // Cache is fresh or plugin execution in progress: serve from cache
       if (!isEffectivelyStale || hasPluginExecutionLock) {
-        return returnCachedResults();
+        return returnCachedResults('cache_hit', { reason: hasPluginExecutionLock ? 'lockActive' : 'freshCache' });
       }
 
       // Cache is stale - queue at most one background refresh job and serve stale data.
@@ -314,10 +439,10 @@ const $bookingsProductSearch = plugins => async ({
         ttl: 60,
       });
       if (!jobQueueLockAcquired) {
-        return returnCachedResults();
+        return returnCachedResults('stale_served', { reason: 'backgroundRefreshDeduped' });
       }
 
-      await addJob({
+      const job = await addJob({
         type: 'plugin',
         pluginName: appKey,
         method: app.searchProducts ? 'searchProducts' : 'searchProductsForItinerary',
@@ -330,13 +455,16 @@ const $bookingsProductSearch = plugins => async ({
         },
       }, { removeOnComplete: true });
 
-      return returnCachedResults();
+      return returnCachedResults('stale_served', {
+        reason: 'backgroundRefreshQueued',
+        jobId: job && job.id,
+      });
     }
   }
 
   // 4. No cache content (and not caught by previous conditions like forceRefresh or doNotCallPluginForProducts):
   //    Fetch from plugin. fetchFromPluginAndCache will handle caching.
-  const funcResults = await fetchFromPluginAndCache();
+  const funcResults = await fetchFromPluginAndCache('cache_miss');
   const searchResults = $searchProductList(funcResults.products, searchInput, optionId);
   return {
     ...funcResults,
@@ -625,22 +753,29 @@ const $updateProductSearchCache = plugins => async ({
     return; // Or throw error
   }
 
-  const cacheKey = hash({ userId, hint, operationId: 'bookingsProductSearch' });
+  const cacheKey = hash({ userId, hint, operationId: productSearchOperationId });
   const monthInSeconds = 30 * 24 * 60 * 60;
   const markRefreshAttempted = () => app.cache.save({
     key: `${cacheKey}:lastUpdated`,
     value: Date.now(),
     ttl: monthInSeconds,
   });
-  const emitCacheEvent = (eventName, extra = {}) => app.events.emit(eventName, {
-    cacheKey, userId, hint, operationId: 'bookingsProductSearch', requestId, pluginName: app.name,
-    ...extra,
-  });
+  const emitCacheEvent = (action, extra = {}) => emitProductSearchCacheDecision({
+    app,
+    cacheKey,
+    userId,
+    hint,
+    requestId,
+    searchInput: '',
+    optionId: '',
+    forceRefresh: false,
+    startedAt: Date.now(),
+  }, action, extra);
 
   if (hasCacheableProductResults(pluginResult)) {
     await markRefreshAttempted();
     await app.cache.save({ key: cacheKey, value: pluginResult, ttl: monthInSeconds });
-    emitCacheEvent('bookingsProductSearch:cache:save');
+    emitCacheEvent('cache_saved', { cacheProductCount: productCount(pluginResult) });
   } else {
     const isPartialRefresh = pluginResult && (pluginResult.catalogPartial || pluginResult.partial);
     const existingCacheContent = await app.cache.get({ key: cacheKey });
@@ -651,9 +786,9 @@ const $updateProductSearchCache = plugins => async ({
         cachePreserved: true,
         existingProductCount: existingCacheContent.products.length,
       };
-      if (isPartialRefresh) eventExtra.pluginResult = pluginResult;
+      if (isPartialRefresh) eventExtra.returnedProductCount = productCount(pluginResult);
       emitCacheEvent(
-        isPartialRefresh ? 'bookingsProductSearch:cache:partialRefreshSkipped' : 'bookingsProductSearch:cache:emptyRefreshSkipped',
+        isPartialRefresh ? 'partial_refresh_skipped' : 'empty_refresh_skipped',
         eventExtra,
       );
       return;
@@ -661,10 +796,10 @@ const $updateProductSearchCache = plugins => async ({
 
     if (isPartialRefresh) {
       await markRefreshAttempted();
-      emitCacheEvent('bookingsProductSearch:cache:partialRefreshSkipped', {
+      emitCacheEvent('partial_refresh_skipped', {
         reason: 'partialResultNotCached',
         cachePreserved: false,
-        pluginResult,
+        returnedProductCount: productCount(pluginResult),
       });
       return;
     }
@@ -673,7 +808,7 @@ const $updateProductSearchCache = plugins => async ({
     const latestCacheContent = await app.cache.get({ key: cacheKey });
     if (hasNonEmptyProductCache(latestCacheContent)) {
       await markRefreshAttempted();
-      emitCacheEvent('bookingsProductSearch:cache:emptyRefreshSkipped', {
+      emitCacheEvent('empty_refresh_skipped', {
         reason: 'emptyResultPreservedConcurrentCache',
         cachePreserved: true,
         existingProductCount: latestCacheContent.products.length,
@@ -684,7 +819,7 @@ const $updateProductSearchCache = plugins => async ({
     // Empty complete refreshes are authoritative only when there is no existing non-empty cache.
     await markRefreshAttempted();
     await app.cache.save({ key: cacheKey, value: { products: [] }, ttl: monthInSeconds });
-    emitCacheEvent('bookingsProductSearch:cache:emptyRefresh');
+    emitCacheEvent('empty_cache_saved', { cacheProductCount: 0 });
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -91,6 +91,8 @@ module.exports = async ({
         getOrExec: args => cache.getOrExec({ ...args, pluginName }),
         save: args => cache.save({ ...args, pluginName }),
         saveIfNotExists: args => cache.saveIfNotExists({ ...args, pluginName }),
+        expireIfValue: args => cache.expireIfValue({ ...args, pluginName }),
+        dropIfValue: args => cache.dropIfValue({ ...args, pluginName }),
         scan: args => cache.scan({ ...args, pluginName }),
       },
       axios: pluginAxios,


### PR DESCRIPTION
## Summary
- Add structured product-search cache decision telemetry with sanitized identifiers, counts, timings, and reason fields.
- Add owner-token Redis lock renewal/release support for product-search cache builds so long-running plugin calls do not outlive the direct lock and allow duplicate upstream work.
- Preserve existing healthy product caches when empty or partial refreshes are non-authoritative, while still allowing true cold empty results to be shared with waiters.
- Extend product-search/cache tests for cache decisions, partial/empty refresh preservation, lock renewal, concurrent requests, and sanitized telemetry payloads.

## Validation
- `npx jest controllers/__tests__/bookings-searchProducts.js __tests__/cache.js --forceExit`
- `git diff --check`