### PR TITLE
[TC-1319] feat: add confirmBooking endpoint (#106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Plugins are the connectores to other systems and/or features you intent to use; 
 |searchAvailability|&check;|&check;|&check;|&check;|&check;|&check;|
 |searchQuote|&check;|&check;|&check;|&check;|&check;|&check;|
 |createBooking|&check;|&check;|&check;|&check;|&check;|&check;|
+|confirmBooking|&check;|&check;|&check;|&check;|&check;|&check;|
 |cancelBooking|&check;|&check;|&check;|&check;|&check;|&check;|
 |searchProductsForItinerary|||||||||&check;|
 |searchAvailabilityForItinerary|||||||||&check;|

--- a/api.yml
+++ b/api.yml
@@ -358,6 +358,39 @@ components:
           type: object
           allOf:     # Combines the BasicErrorModel and the inline model
             - $ref: '#/components/schemas/bookingDetail'
+    bookingDetailsForConfirm:
+      type: object
+      additionalProperties: true
+      description: Booking identifier; provide bookingId, id, ref, or reference
+      properties:
+        bookingId:
+          type: string
+        id:
+          type: string
+        ref:
+          type: string
+        reference:
+          type: string
+    confirmBookingReturn:
+      type: object
+      additionalProperties: true
+      properties:
+        confirmBookingReply:
+          type: object
+        booking:
+          type: object
+          properties:
+            ref:
+              type: string
+            id:
+              type: string
+            status:
+              type: string
+            serviceLines:
+              type: array
+              items:
+                type: object
+                additionalProperties: true
     packageSearchQuery:
       type: object
       additionalProperties: true
@@ -1815,6 +1848,85 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/cancellationReturn'
+  /bookings/{appKey}/{userId}/confirm:
+    post:
+      security:
+        - bearerAuth: ['admin', 'user']
+      tags:
+        - bookings
+      summary: Confirms a quote as a booking
+      operationId: confirmBooking
+      parameters:
+        - name: appKey
+          in: path
+          description: app to confirm the booking for, defaults to first token
+          required: true
+          example: 'travelgate-hotelx'
+          schema:
+            type: string
+        - name: userId
+          in: path
+          description: the user/company that the appKey belongs to
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Booking identifier to confirm
+        required:  true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/bookingDetailsForConfirm'
+      responses:
+        '200':
+          description: Booking confirmation details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/confirmBookingReturn'
+  /bookings/{appKey}/{userId}/{hint}/confirm:
+    post:
+      security:
+        - bearerAuth: ['admin', 'user']
+      tags:
+        - bookings
+      summary: Confirms a quote as a booking for a specific hint
+      operationId: confirmBooking
+      parameters:
+        - name: appKey
+          in: path
+          description: app to confirm the booking for
+          required: true
+          example: 'travelgate'
+          schema:
+            type: string
+        - name: userId
+          in: path
+          description: the user/company that the appKey belongs to
+          required: true
+          schema:
+            type: string
+        - name: hint
+          in: path
+          description: a specific token hint to be used
+          required: true
+          example: 'travelgate-australia'
+          schema:
+            type: string
+      requestBody:
+        description: Booking identifier to confirm
+        required:  true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/bookingDetailsForConfirm'
+      responses:
+        '200':
+          description: Booking confirmation details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/confirmBookingReturn'
   /packages/{appKey}/{userId}/search:
     post:
       security:

--- a/controllers/__tests__/bookings.js
+++ b/controllers/__tests__/bookings.js
@@ -170,6 +170,32 @@ describe('user: bookings controller', () => {
     expect(plugins[0].createBooking.mock.calls[0][0].payload).toEqual(payload);
     expect(plugins[0].createBooking.mock.calls[0][0].token).toEqual(token);
   });
+  it('should be able to confirm a booking (with hint)', async () => {
+    const payload = {
+      bookingId: '14226',
+    };
+    await doApiPost({
+      url: `/bookings/${appKey}/${userId}/testingToken/confirm`,
+      token: userToken,
+      payload,
+    });
+    expect(plugins[0].confirmBooking).toHaveBeenCalled();
+    expect(plugins[0].confirmBooking.mock.calls[0][0].payload).toEqual(payload);
+    expect(plugins[0].confirmBooking.mock.calls[0][0].token).toEqual(token);
+  });
+  it('should be able to confirm a booking (no hint)', async () => {
+    const payload = {
+      bookingId: '14226',
+    };
+    await doApiPost({
+      url: `/bookings/${appKey}/${userId}/confirm`,
+      token: userToken,
+      payload,
+    });
+    expect(plugins[0].confirmBooking).toHaveBeenCalled();
+    expect(plugins[0].confirmBooking.mock.calls[0][0].payload).toEqual(payload);
+    expect(plugins[0].confirmBooking.mock.calls[0][0].token).toEqual(token);
+  });
   it('should forward inline credentials directly to create booking', async () => {
     const payload = {
       id: chance.guid(),

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -181,6 +181,38 @@ const bookingsCancel = plugins => async (req, res, next) => {
   }
 };
 
+const confirmBooking = plugins => async (req, res, next) => {
+  const {
+    axios,
+    params: { appKey, userId, hint },
+    body,
+  } = req;
+  try {
+    const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
+    assert(app.confirmBooking, `confirmBooking is not available for ${appKey}`);
+    const results = await app.confirmBooking({
+      axios,
+      token,
+      payload: body,
+      typeDefsAndQueries,
+      userId,
+      hint,
+      requestId: req.requestId,
+    });
+    app.events.emit('bookingsConfirmBooking', {
+      userId,
+      hint,
+      operationId: 'confirmBooking',
+      requestId: req.requestId,
+      pluginName: app.name,
+      payload: results,
+    });
+    return res.json(results);
+  } catch (err) {
+    return next(err);
+  }
+};
+
 const $searchProductList = (products, searchInput = '', optionId = '') => {
   // NOTE: optionId could be a string or an array of strings
   // NOTE: searchInput should not appear at the same time as optionId
@@ -842,6 +874,7 @@ const controllerFactory = plugins => {
   const controllerFunctions = {
     bookingsSearch: bookingsSearch(plugins),
     bookingsCancel: bookingsCancel(plugins),
+    confirmBooking: confirmBooking(plugins),
     $bookingsProductSearch: $bookingsProductSearch(plugins),
     bookingsProductSearch: bookingsProductSearch(plugins),
     getProductPackages: getProductPackages(plugins),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2",
-  "version": "1.0.116",
+  "version": "1.0.117",
   "description": "Tourist Industry Exchange (TI2)",
   "main": "index.js",
   "scripts": {

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -75,6 +75,14 @@ class Plugin {
     });
     this.searchQuote = jestPlugin.fn(() => ({ quote: [{ id: chance.guid() }] }));
     this.createBooking = jestPlugin.fn(() => {});
+    this.confirmBooking = jestPlugin.fn(() => ({
+      confirmBookingReply: {},
+      booking: {
+        id: chance.guid(),
+        status: 'OK',
+        serviceLines: [],
+      },
+    }));
     this.getAffiliateAgents = jestPlugin.fn(() => ({ agents: [] }));
     this.searchItineraries = jestPlugin.fn(() => ({ bookings: [] }));
     this.searchProductsForItinerary = jestPlugin.fn(() => ({ products: [] }));
@@ -534,6 +542,22 @@ class Plugin {
    * @returns {Booking} retVal.booking - A Booking object.
    */
   createBooking() {}
+
+  /**
+   * Confirm a quote as a booking
+   * @async
+   * @param {Object} args - Confirm booking arguments.
+   * @param {Object} args.token - A token definition, it's content varies between integrations.
+   * @param {Object} args.payload - Booking identifier payload.
+   * @param {string} [args.payload.bookingId] - Booking id to confirm.
+   * @param {string} [args.payload.id] - Booking id to confirm.
+   * @param {string} [args.payload.ref] - Booking reference to confirm.
+   * @param {string} [args.payload.reference] - Booking reference to confirm.
+   * @returns {object} retVal - the return object.
+   * @returns {Object} retVal.confirmBookingReply - Raw integration reply.
+   * @returns {Booking} retVal.booking - A normalized Booking object.
+   */
+  confirmBooking() {}
 
   /**
    * @typedef {Object} Passenger

--- a/tutorials/plugin-development.md
+++ b/tutorials/plugin-development.md
@@ -39,6 +39,7 @@ We are using a set of standardized methods to maintain compatibility; the follow
 * [searchAvailability]{@link Plugin#searchAvailability}
 * [searchQuote]{@link Plugin#searchQuote}
 * [createBooking]{@link Plugin#createBooking}
+* [confirmBooking]{@link Plugin#confirmBooking}
 * [searchProductsForItinerary]{@link Plugin#searchProductsForItinerary}
 * [searchAvailabilityForItinerary]{@link Plugin#searchAvailabilityForItinerary}
 * [addServiceToItinerary]{@link Plugin#addServiceToItinerary}


### PR DESCRIPTION
Introduces a new `confirmBooking` operation to allow plugins to confirm a quote as a booking, following the same patterns established by createBooking and cancelBooking.

- Added `confirmBooking` request handler with capability guard (`assert(app.confirmBooking, ...)`) consistent with other optional methods such as getAffiliateAgents and getPickupPoints
- Emits `bookingsConfirmBooking` event on success, matching the lifecycle event pattern used by `bookingsCreateBooking`
- Registered in the controller factory so swagger-routes-express wires it to the correct operationId automatically

- Added two new POST routes: /bookings/{appKey}/{userId}/confirm /bookings/{appKey}/{userId}/{hint}/confirm
- Added request schema `bookingDetailsForConfirm` (accepts bookingId, id, ref, or reference)
- Added response schema `confirmBookingReturn` (confirmBookingReply + booking)

- Added test for the hint variant: /bookings/:appKey/:userId/:hint/confirm
- Added test for the no-hint variant: /bookings/:appKey/:userId/confirm
- Both assert correct payload and token forwarding to the plugin

- Added `confirmBooking` jest mock returning a valid { confirmBookingReply, booking: { id, status, serviceLines } } shape
- Added JSDoc stub `confirmBooking() {}` marking it as an optional method

- README.md: added confirmBooking to the Bookings feature matrix
- tutorials/plugin-development.md: listed confirmBooking in the standard methods section