### PR TITLE
[TC-1318] feat(bookings): add cancelBooking capability guard, event emission, and test coverage

### DIFF
--- a/controllers/__tests__/bookings.js
+++ b/controllers/__tests__/bookings.js
@@ -196,6 +196,33 @@ describe('user: bookings controller', () => {
     expect(plugins[0].confirmBooking.mock.calls[0][0].payload).toEqual(payload);
     expect(plugins[0].confirmBooking.mock.calls[0][0].token).toEqual(token);
   });
+  it('should emit cancelBooking operation metadata when cancelling', async () => {
+    const payload = {
+      bookingId: chance.guid(),
+    };
+    const emitSpy = jest.spyOn(plugins[0].events, 'emit');
+    try {
+      await doApiPost({
+        url: `/bookings/${appKey}/${userId}/testingToken/cancel`,
+        token: userToken,
+        payload,
+      });
+      expect(plugins[0].cancelBooking).toHaveBeenCalled();
+      expect(plugins[0].cancelBooking.mock.calls[0][0].payload).toEqual(payload);
+      expect(plugins[0].cancelBooking.mock.calls[0][0].token).toEqual(token);
+      expect(emitSpy).toHaveBeenCalledWith(
+        'bookingsCancelBooking',
+        expect.objectContaining({
+          userId,
+          hint: 'testingToken',
+          operationId: 'cancelBooking',
+          pluginName: appKey,
+        }),
+      );
+    } finally {
+      emitSpy.mockRestore();
+    }
+  });
   it('should forward inline credentials directly to create booking', async () => {
     const payload = {
       id: chance.guid(),

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -166,6 +166,7 @@ const bookingsCancel = plugins => async (req, res, next) => {
   } = req;
   try {
     const { app, token } = await getAppAndToken({ plugins, appKey, userId, hint });
+    assert(app.cancelBooking, `cancelBooking is not available for ${appKey}`);
     const results = await app.cancelBooking({
       axios,
       token,
@@ -174,6 +175,14 @@ const bookingsCancel = plugins => async (req, res, next) => {
       userId,
       hint,
       requestId: req.requestId,
+    });
+    app.events.emit('bookingsCancelBooking', {
+      userId,
+      hint,
+      operationId: 'cancelBooking',
+      requestId: req.requestId,
+      pluginName: app.name,
+      payload: results,
     });
     return res.json(results);
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ti2",
-  "version": "1.0.117",
+  "version": "1.0.118",
   "description": "Tourist Industry Exchange (TI2)",
   "main": "index.js",
   "scripts": {

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -75,6 +75,13 @@ class Plugin {
     });
     this.searchQuote = jestPlugin.fn(() => ({ quote: [{ id: chance.guid() }] }));
     this.createBooking = jestPlugin.fn(() => {});
+    this.cancelBooking = jestPlugin.fn(() => ({
+      cancelServicesReply: {},
+      cancellation: {
+        id: chance.guid(),
+        status: 'Cancelled',
+      },
+    }));
     this.confirmBooking = jestPlugin.fn(() => ({
       confirmBookingReply: {},
       booking: {
@@ -542,6 +549,16 @@ class Plugin {
    * @returns {Booking} retVal.booking - A Booking object.
    */
   createBooking() {}
+
+  /**
+   * Cancel a booking
+   * @async
+   * @param {Object} args - Cancel booking arguments.
+   * @param {Object} args.token - A token definition, it's content varies between integrations.
+   * @param {Object} args.payload - Booking identifier payload.
+   * @returns {object} retVal - the return object.
+   */
+  cancelBooking() {}
 
   /**
    * Confirm a quote as a booking

--- a/tutorials/plugin-development.md
+++ b/tutorials/plugin-development.md
@@ -39,6 +39,7 @@ We are using a set of standardized methods to maintain compatibility; the follow
 * [searchAvailability]{@link Plugin#searchAvailability}
 * [searchQuote]{@link Plugin#searchQuote}
 * [createBooking]{@link Plugin#createBooking}
+* [cancelBooking]{@link Plugin#cancelBooking}
 * [confirmBooking]{@link Plugin#confirmBooking}
 * [searchProductsForItinerary]{@link Plugin#searchProductsForItinerary}
 * [searchAvailabilityForItinerary]{@link Plugin#searchAvailabilityForItinerary}


### PR DESCRIPTION
Brings the cancel booking flow to parity with confirmBooking and createBooking by adding a plugin capability guard, emitting a structured lifecycle event after successful cancellation, and locking the contract in tests.

Controllers (controllers/bookings.js):
- Add assert(app.cancelBooking, ...) before invocation so requests to integrations that have not implemented cancellation fail fast with a clear, integration-specific error message rather than an unhelpful TypeError at call time.
- Emit 'bookingsCancelBooking' after a successful cancel response, carrying userId, hint, requestId, pluginName, operationId: 'cancelBooking', and the result payload. Shape and field names are identical to the 'bookingsConfirmBooking' and 'bookingsCreateBooking' events to maintain consistency for downstream consumers (analytics, audit, event-driven integrations).

Tests (controllers/__tests__/bookings.js):
- Add integration test 'should emit cancelBooking operation metadata when cancelling' covering the /bookings/:appKey/:userId/:hint/cancel endpoint.
- Use jest.spyOn on the shared ti2Events EventEmitter2 instance (plugins[0].events) scoped to the test with try/finally + mockRestore() to prevent cross-test pollution.
- Assert plugin invocation, payload and token forwarding, and full emitted event metadata including operationId: 'cancelBooking'.

Test plugin scaffold (test/plugin.js):
- Add mocked cancelBooking implementation returning a well-formed cancellationReturn object ({ cancelServicesReply, cancellation: { id, status: 'Cancelled' } }) so controller tests receive a realistic response shape.
- Add JSDoc stub for cancelBooking() consistent with createBooking/confirmBooking stubs, ensuring generated plugin documentation covers the new method.

Docs (tutorials/plugin-development.md):
- Add cancelBooking to the standardised booking methods list, positioned between createBooking and confirmBooking to reflect the booking lifecycle order.

Version: bump 1.0.117 → 1.0.118