### PR TITLE
TC-1323: include scope on legacy cache events

### DIFF
--- a/controllers/__tests__/bookings-searchProducts.js
+++ b/controllers/__tests__/bookings-searchProducts.js
@@ -198,6 +198,26 @@ describe('user: bookings controller - searchProducts', () => {
         });
         emitSpy.mockRestore();
       });
+
+      it('includes raw scope only on legacy cache-save events', async () => {
+        const emitSpy = jest.spyOn(travelgatePlugin.events, 'emit');
+        await doApiPost({
+          url: `/products/${testAppName}/${testUserId}/${testHint}/search`,
+          token: userToken,
+          payload: { forceRefresh: true },
+        });
+        const cacheSavePayload = emitSpy.mock.calls
+          .filter(call => call[0] === 'bookingsProductSearch:cache:save')
+          .map(call => call[1])
+          .find(payload => payload.action === 'cache_saved');
+
+        expect(cacheSavePayload).toBeTruthy();
+        expect(cacheSavePayload.userId).toBe(testUserId);
+        expect(cacheSavePayload.hint).toBe(testHint);
+        expect(cacheSavePayload.userIdHash).toBeTruthy();
+        expect(cacheSavePayload.hintHash).toBeTruthy();
+        emitSpy.mockRestore();
+      });
     });
     describe('doNotCallPluginForProducts flag', () => {
       const doNotCallHint = 'hint_for_doNotCallPluginForProducts';

--- a/controllers/bookings.js
+++ b/controllers/bookings.js
@@ -76,7 +76,11 @@ const emitProductSearchCacheDecision = ({ app, cacheKey, userId, hint, requestId
   };
   app.events.emit(productSearchCacheDecisionEvent, payload);
   if (legacyProductSearchCacheEvents[action]) {
-    app.events.emit(legacyProductSearchCacheEvents[action], payload);
+    app.events.emit(legacyProductSearchCacheEvents[action], {
+      ...payload,
+      userId,
+      hint,
+    });
   }
 };
 


### PR DESCRIPTION
## Summary
- Include raw `userId` and `hint` only on legacy product-cache event payloads.
- Keep the general cache-decision telemetry event sanitized with hashed scope fields.
- Add coverage for the legacy cache-save event payload shape.

## Validation
- `git diff --check`
- Attempted targeted Jest run in the existing Docker image, but it did not complete within 5 minutes and produced no output.